### PR TITLE
Remove self dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "aegir": "^12.2.0",
     "benchmark": "^2.1.4",
     "protocol-buffers": "^3.2.1",
-    "protons": "^1.0.0",
     "tape": "^4.8.0"
   },
   "scripts": {


### PR DESCRIPTION
This package is breaking in my build pipeline (Meteor.js).

I can't see any reason why this circular dependency would be necessary, and hopefully it will fix this issue.