### PR TITLE
feat: support Uint8Array input in place of Buffer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ stages:
   - cov
 
 node_js:
+  - '10'
   - '12'
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ node_js:
   - '10'
   - '12'
   - '14'
-  - 'current'
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ stages:
 node_js:
   - '10'
   - '12'
+  - '14'
+  - 'current'
 
 os:
   - linux

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "varint": "^5.0.0"
   },
   "devDependencies": {
+    "ipfs-utils": "^2.3.0",
     "aegir": "^21.4.0",
     "benchmark": "^2.1.4",
     "protocol-buffers": "^4.1.0",

--- a/src/compile/encodings.js
+++ b/src/compile/encodings.js
@@ -4,32 +4,6 @@ var varint = require('varint')
 var svarint = require('signed-varint')
 const { Buffer } = require('buffer')
 
-/**
- * @template T
- * @typedef {{bytes?:number} & function(T, Buffer, number):Buffer} Encoder
- */
-/**
- * @template T
- * @typedef {{bytes?:number} & function(Buffer, number):T} Decoder
- */
-
-/**
- * @template T
- * @typedef {Object} Codec
- * @property {number} type
- * @property {Encoder<T>} encode
- * @property {Decoder<T>} decode
- * @property {function(T):number} encodingLength
- */
-
-/**
- * @template T
- * @param {number} type
- * @param {Encoder<T>} encode
- * @param {Decoder<T>} decode
- * @param {function(T):number} encodingLength
- * @returns {Codec<T>}
- */
 var encoder = function (type, encode, decode, encodingLength) {
   encode.bytes = decode.bytes = 0
 
@@ -43,12 +17,7 @@ var encoder = function (type, encode, decode, encodingLength) {
 
 exports.make = encoder
 
-/** @type {Codec<Uint8Array>} */
 exports.bytes = (function () {
-  /**
-   * @param {Uint8Array|string} val
-   * @returns {number}
-   */
   var bufferLength = function (val) {
     return Buffer.isBuffer(val) ? val.length : Buffer.byteLength(val)
   }
@@ -89,7 +58,6 @@ exports.bytes = (function () {
   return encoder(2, encode, decode, encodingLength)
 })()
 
-/** @type {Codec<string>} */
 exports.string = (function () {
   var encodingLength = function (val) {
     var len = Buffer.byteLength(val)
@@ -126,12 +94,7 @@ exports.string = (function () {
   return encoder(2, encode, decode, encodingLength)
 })()
 
-/** @type {Codec<boolean>} */
 exports.bool = (function () {
-  /**
-   * @param {boolean} val
-   * @returns {number}
-   */
   var encodingLength = function (val) {
     return 1
   }
@@ -151,7 +114,6 @@ exports.bool = (function () {
   return encoder(0, encode, decode, encodingLength)
 })()
 
-/** @type {Codec<number>} */
 exports.int32 = (function () {
   var decode = function (buffer, offset) {
     var val = varint.decode(buffer, offset)
@@ -172,7 +134,6 @@ exports.int32 = (function () {
   return encoder(0, encode, decode, encodingLength)
 })()
 
-/** @type {Codec<number>} */
 exports.int64 = (function () {
   var decode = function (buffer, offset) {
     var val = varint.decode(buffer, offset)
@@ -217,13 +178,11 @@ exports.int64 = (function () {
   return encoder(0, encode, decode, encodingLength)
 })()
 
-/** @type {Codec<number>} */
 exports.sint32 =
 exports.sint64 = (function () {
   return encoder(0, svarint.encode, svarint.decode, svarint.encodingLength)
 })()
 
-/** @type {Codec<number>} */
 exports.uint32 =
 exports.uint64 =
 exports.enum =
@@ -232,7 +191,6 @@ exports.varint = (function () {
 })()
 
 // we cannot represent these in javascript so we just use buffers
-/** @type {Codec<Uint8Array>} */
 exports.fixed64 =
 exports.sfixed64 = (function () {
   var encodingLength = function (val) {
@@ -274,7 +232,6 @@ exports.double = (function () {
   return encoder(1, encode, decode, encodingLength)
 })()
 
-/** @type {Codec<number>} */
 exports.fixed32 = (function () {
   var encodingLength = function (val) {
     return 4
@@ -295,7 +252,6 @@ exports.fixed32 = (function () {
   return encoder(5, encode, decode, encodingLength)
 })()
 
-/** @type {Codec<number>} */
 exports.sfixed32 = (function () {
   var encodingLength = function (val) {
     return 4
@@ -316,7 +272,6 @@ exports.sfixed32 = (function () {
   return encoder(5, encode, decode, encodingLength)
 })()
 
-/** @type {Codec<number>} */
 exports.float = (function () {
   var encodingLength = function (val) {
     return 4

--- a/test/bytes.js
+++ b/test/bytes.js
@@ -6,7 +6,7 @@ var Bytes = protobuf(require('./test.proto')).Bytes
 
 tape('bytes encode + decode', function (t) {
   var b1 = Bytes.encode({
-    req: Buffer.from([0, 1, 2, 3])
+    req: Uint8Array.from([0, 1, 2, 3])
   })
 
   var o1 = Bytes.decode(b1)

--- a/test/corrupted.js
+++ b/test/corrupted.js
@@ -27,7 +27,7 @@ var messages = protobuf(protoStr)
 tape('invalid message decode', function (t) {
   var didFail = false
   try {
-    messages.ABC.decode(Buffer.from([8, 182, 168, 235, 144, 178, 41]))
+    messages.ABC.decode(Uint8Array.from([8, 182, 168, 235, 144, 178, 41]))
   } catch (e) {
     didFail = true
   }

--- a/test/custom-types.js
+++ b/test/custom-types.js
@@ -8,7 +8,7 @@ tape('custom types encode + decode', function (t) {
   var b1 = CustomType.encode({
     req: {
       num: 5,
-      payload: Buffer.from([])
+      payload: Uint8Array.from([])
     }
   })
 

--- a/test/nested.js
+++ b/test/nested.js
@@ -7,20 +7,20 @@ var Nested = protobuf(require('./test.proto')).Nested
 tape('nested encode', function (t) {
   var b1 = Nested.encode({
     num: 1,
-    payload: Buffer.from('lol'),
+    payload: new TextEncoder().encode('lol'),
     meh: {
       num: 2,
-      payload: Buffer.from('bar')
+      payload: new TextEncoder().encode('bar')
     }
   })
 
   var b2 = Nested.encode({
     num: 1,
-    payload: Buffer.from('lol'),
+    payload: new TextEncoder().encode('lol'),
     meeeh: 42,
     meh: {
       num: 2,
-      payload: Buffer.from('bar')
+      payload: new TextEncoder().encode('bar')
     }
   })
 
@@ -31,10 +31,10 @@ tape('nested encode', function (t) {
 tape('nested encode + decode', function (t) {
   var b1 = Nested.encode({
     num: 1,
-    payload: Buffer.from('lol'),
+    payload: new TextEncoder().encode('lol'),
     meh: {
       num: 2,
-      payload: Buffer.from('bar')
+      payload: new TextEncoder().encode('bar')
     }
   })
 
@@ -48,11 +48,11 @@ tape('nested encode + decode', function (t) {
 
   var b2 = Nested.encode({
     num: 1,
-    payload: Buffer.from('lol'),
+    payload: new TextEncoder().encode('lol'),
     meeeh: 42,
     meh: {
       num: 2,
-      payload: Buffer.from('bar')
+      payload: new TextEncoder().encode('bar')
     }
   })
 

--- a/test/nested.js
+++ b/test/nested.js
@@ -2,6 +2,8 @@
 
 var tape = require('tape')
 var protobuf = require('../')
+const TextEncoder = require('ipfs-utils/src/text-encoder')
+
 var Nested = protobuf(require('./test.proto')).Nested
 
 tape('nested encode', function (t) {

--- a/test/repeated.js
+++ b/test/repeated.js
@@ -8,20 +8,20 @@ tape('repeated encode', function (t) {
   var b1 = Repeated.encode({
     list: [{
       num: 1,
-      payload: Buffer.from('lol')
+      payload: new TextEncoder().encode('lol')
     }, {
       num: 2,
-      payload: Buffer.from('lol1')
+      payload: new TextEncoder().encode('lol1')
     }]
   })
 
   var b2 = Repeated.encode({
     list: [{
       num: 1,
-      payload: Buffer.from('lol')
+      payload: new TextEncoder().encode('lol')
     }, {
       num: 2,
-      payload: Buffer.from('lol1'),
+      payload: new TextEncoder().encode('lol1'),
       meeeeh: 100
     }],
     meeh: 42
@@ -35,10 +35,10 @@ tape('repeated encode + decode', function (t) {
   var b1 = Repeated.encode({
     list: [{
       num: 1,
-      payload: Buffer.from('lol')
+      payload: new TextEncoder().encode('lol')
     }, {
       num: 2,
-      payload: Buffer.from('lol1')
+      payload: new TextEncoder().encode('lol1')
     }]
   })
 
@@ -53,10 +53,10 @@ tape('repeated encode + decode', function (t) {
   var b2 = Repeated.encode({
     list: [{
       num: 1,
-      payload: Buffer.from('lol')
+      payload: new TextEncoder().encode('lol')
     }, {
       num: 2,
-      payload: Buffer.from('lol1'),
+      payload: new TextEncoder().encode('lol1'),
       meeeeh: 100
     }],
     meeh: 42

--- a/test/repeated.js
+++ b/test/repeated.js
@@ -3,6 +3,7 @@
 var tape = require('tape')
 var protobuf = require('../')
 var Repeated = protobuf(require('./test.proto')).Repeated
+const TextEncoder = require('ipfs-utils/src/text-encoder')
 
 tape('repeated encode', function (t) {
   var b1 = Repeated.encode({


### PR DESCRIPTION
With this change all the `Buffer` inputs were replaced by `Uint8Array` which is backwards compatible since `Buffer` is a subclass.

This does make an assumption that "bytes" encoder used to take `Buffer|string` here:

https://github.com/ipfs/protons/blob/3b5276f052f2e17c2d806d27cd9a88e156588977/src/compile/encodings.js#L30-L43


Fixes #12 