### PR TITLE
fix: remove redundant defs and declare codec return type

### DIFF
--- a/packages/protons-runtime/src/codec.ts
+++ b/packages/protons-runtime/src/codec.ts
@@ -24,13 +24,13 @@ export interface EncodingLengthFunction<T> {
 
 export interface Codec<T> {
   name: string
-  type: number
+  type: CODEC_TYPES
   encode: EncodeFunction<T>
   decode: DecodeFunction<T>
   encodingLength: EncodingLengthFunction<T>
 }
 
-export function createCodec <T> (name: string, type: number, encode: EncodeFunction<T>, decode: DecodeFunction<T>, encodingLength: EncodingLengthFunction<T>): Codec<T> {
+export function createCodec <T> (name: string, type: CODEC_TYPES, encode: EncodeFunction<T>, decode: DecodeFunction<T>, encodingLength: EncodingLengthFunction<T>): Codec<T> {
   return {
     name,
     type,

--- a/packages/protons-runtime/src/codecs/bool.ts
+++ b/packages/protons-runtime/src/codecs/bool.ts
@@ -1,4 +1,5 @@
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 
 const encodingLength: EncodingLengthFunction<boolean> = function boolEncodingLength () {
   return 1

--- a/packages/protons-runtime/src/codecs/bytes.ts
+++ b/packages/protons-runtime/src/codecs/bytes.ts
@@ -1,7 +1,8 @@
 
 import { Uint8ArrayList } from 'uint8arraylist'
 import { unsigned } from '../utils/varint.js'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 
 const encodingLength: EncodingLengthFunction<Uint8Array> = function bytesEncodingLength (val) {
   const len = val.byteLength

--- a/packages/protons-runtime/src/codecs/double.ts
+++ b/packages/protons-runtime/src/codecs/double.ts
@@ -1,5 +1,6 @@
 import { Uint8ArrayList } from 'uint8arraylist'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 
 const encodingLength: EncodingLengthFunction<number> = function doubleEncodingLength () {
   return 8

--- a/packages/protons-runtime/src/codecs/enum.ts
+++ b/packages/protons-runtime/src/codecs/enum.ts
@@ -1,6 +1,7 @@
 
 import { unsigned } from '../utils/varint.js'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, Codec, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction, Codec } from '../codec.js'
 
 export function enumeration <T> (e: T): Codec<T> {
   const encodingLength: EncodingLengthFunction<string> = function enumEncodingLength (val: string) {

--- a/packages/protons-runtime/src/codecs/fixed32.ts
+++ b/packages/protons-runtime/src/codecs/fixed32.ts
@@ -1,5 +1,6 @@
 import { Uint8ArrayList } from 'uint8arraylist'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 
 const encodingLength: EncodingLengthFunction<number> = function fixed32EncodingLength () {
   return 4

--- a/packages/protons-runtime/src/codecs/fixed64.ts
+++ b/packages/protons-runtime/src/codecs/fixed64.ts
@@ -1,5 +1,6 @@
 import { Uint8ArrayList } from 'uint8arraylist'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 
 const encodingLength: EncodingLengthFunction<bigint> = function int64EncodingLength (val) {
   return 8

--- a/packages/protons-runtime/src/codecs/float.ts
+++ b/packages/protons-runtime/src/codecs/float.ts
@@ -1,5 +1,6 @@
 import { Uint8ArrayList } from 'uint8arraylist'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 
 const encodingLength: EncodingLengthFunction<number> = function floatEncodingLength () {
   return 4

--- a/packages/protons-runtime/src/codecs/int32.ts
+++ b/packages/protons-runtime/src/codecs/int32.ts
@@ -1,5 +1,6 @@
 import { signed } from '../utils/varint.js'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 
 const encodingLength: EncodingLengthFunction<number> = function int32EncodingLength (val) {
   return signed.encodingLength(val)

--- a/packages/protons-runtime/src/codecs/int64.ts
+++ b/packages/protons-runtime/src/codecs/int64.ts
@@ -1,5 +1,6 @@
 import { signed } from '../utils/big-varint.js'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 
 const encodingLength: EncodingLengthFunction<bigint> = function int64EncodingLength (val) {
   return signed.encodingLength(val)

--- a/packages/protons-runtime/src/codecs/message.ts
+++ b/packages/protons-runtime/src/codecs/message.ts
@@ -1,7 +1,8 @@
 import { unsigned } from '../utils/varint.js'
-import type { FieldDef, FieldDefs } from '../index.js'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, Codec, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction, Codec } from '../codec.js'
 import { Uint8ArrayList } from 'uint8arraylist'
+import type { FieldDefs, FieldDef } from '../index.js'
 
 export interface Factory<A, T> {
   new (obj: A): T

--- a/packages/protons-runtime/src/codecs/sfixed32.ts
+++ b/packages/protons-runtime/src/codecs/sfixed32.ts
@@ -1,5 +1,6 @@
 import { Uint8ArrayList } from 'uint8arraylist'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 
 const encodingLength: EncodingLengthFunction<number> = function sfixed32EncodingLength () {
   return 4

--- a/packages/protons-runtime/src/codecs/sfixed64.ts
+++ b/packages/protons-runtime/src/codecs/sfixed64.ts
@@ -1,5 +1,6 @@
 import { Uint8ArrayList } from 'uint8arraylist'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 
 const encodingLength: EncodingLengthFunction<bigint> = function sfixed64EncodingLength () {
   return 8

--- a/packages/protons-runtime/src/codecs/sint32.ts
+++ b/packages/protons-runtime/src/codecs/sint32.ts
@@ -1,5 +1,6 @@
 import { zigzag } from '../utils/varint.js'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 
 const encodingLength: EncodingLengthFunction<number> = function sint32EncodingLength (val) {
   return zigzag.encodingLength(val)

--- a/packages/protons-runtime/src/codecs/sint64.ts
+++ b/packages/protons-runtime/src/codecs/sint64.ts
@@ -1,5 +1,6 @@
 import { zigzag } from '../utils/big-varint.js'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 
 const encodingLength: EncodingLengthFunction<bigint> = function int64EncodingLength (val) {
   return zigzag.encodingLength(val)

--- a/packages/protons-runtime/src/codecs/string.ts
+++ b/packages/protons-runtime/src/codecs/string.ts
@@ -1,7 +1,8 @@
 import { unsigned } from '../utils/varint.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 import { Uint8ArrayList } from 'uint8arraylist'
 
 const encodingLength: EncodingLengthFunction<string> = function stringEncodingLength (val) {

--- a/packages/protons-runtime/src/codecs/uint32.ts
+++ b/packages/protons-runtime/src/codecs/uint32.ts
@@ -1,5 +1,6 @@
 import { unsigned } from '../utils/varint.js'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 
 const encodingLength: EncodingLengthFunction<number> = function uint32EncodingLength (val) {
   return unsigned.encodingLength(val)

--- a/packages/protons-runtime/src/codecs/uint64.ts
+++ b/packages/protons-runtime/src/codecs/uint64.ts
@@ -1,5 +1,6 @@
 import { unsigned } from '../utils/big-varint.js'
-import { DecodeFunction, EncodeFunction, createCodec, EncodingLengthFunction, CODEC_TYPES } from './codec.js'
+import { createCodec, CODEC_TYPES } from '../codec.js'
+import type { DecodeFunction, EncodeFunction, EncodingLengthFunction } from '../codec.js'
 
 const encodingLength: EncodingLengthFunction<bigint> = function uint64EncodingLength (val) {
   return unsigned.encodingLength(val)

--- a/packages/protons-runtime/src/decode.ts
+++ b/packages/protons-runtime/src/decode.ts
@@ -1,6 +1,6 @@
 import { Uint8ArrayList } from 'uint8arraylist'
 import { unsigned } from './utils/varint.js'
-import type { Codec } from './codecs/codec.js'
+import type { Codec } from './codec.js'
 
 export function decodeMessage <T> (buf: Uint8Array, codec: Codec<T>) {
   // wrap root message

--- a/packages/protons-runtime/src/encode.ts
+++ b/packages/protons-runtime/src/encode.ts
@@ -1,4 +1,4 @@
-import type { Codec } from './codecs/codec.js'
+import type { Codec } from './codec.js'
 import { unsigned } from './utils/varint.js'
 
 export function encodeMessage <T> (message: T, codec: Codec<T>) {

--- a/packages/protons-runtime/src/index.ts
+++ b/packages/protons-runtime/src/index.ts
@@ -1,4 +1,4 @@
-import type { Codec } from './codecs/codec.js'
+import type { Codec } from './codec.js'
 
 export interface FieldDef {
   name: string
@@ -35,3 +35,4 @@ export { sint64 } from './codecs/sint64.js'
 export { string } from './codecs/string.js'
 export { uint32 } from './codecs/uint32.js'
 export { uint64 } from './codecs/uint64.js'
+export type { Codec } from './codec.js'

--- a/packages/protons-runtime/tsconfig.json
+++ b/packages/protons-runtime/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "aegir/src/config/tsconfig.aegir.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "emitDeclarationOnly": false,
-    "module": "ES2020"
+    "outDir": "dist"
   },
   "include": [
     "src",

--- a/packages/protons/bin/protons.ts
+++ b/packages/protons/bin/protons.ts
@@ -6,13 +6,13 @@ import { generate } from '../src/index.js'
 async function main () {
   const cli = meow(`
   Usage
-    $ protons source
+    $ protons source...
 
   Options
-    --output, -o  Path to a directory to write transpiled typescript files into
+    --output, -o Path to a directory to write transpiled typescript files into
 
   Examples
-    $ protons ./path/to/file.proto
+    $ protons ./path/to/file.proto ./path/to/other/file.proto
 `, {
     importMeta: import.meta,
     flags: {

--- a/packages/protons/test/fixtures/basic.ts
+++ b/packages/protons/test/fixtures/basic.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 
 import { encodeMessage, decodeMessage, message, string, int32 } from 'protons-runtime'
+import type { Codec } from 'protons-runtime'
 
 export interface Basic {
   foo: string
@@ -9,16 +10,18 @@ export interface Basic {
 }
 
 export namespace Basic {
-  export const codec = message<Basic>({
-    1: { name: 'foo', codec: string },
-    2: { name: 'num', codec: int32 }
-  })
+  export const codec = (): Codec<Basic> => {
+    return message<Basic>({
+      1: { name: 'foo', codec: string },
+      2: { name: 'num', codec: int32 }
+    })
+  }
 
   export const encode = (obj: Basic): Uint8Array => {
-    return encodeMessage(obj, Basic.codec)
+    return encodeMessage(obj, Basic.codec())
   }
 
   export const decode = (buf: Uint8Array): Basic => {
-    return decodeMessage(buf, Basic.codec)
+    return decodeMessage(buf, Basic.codec())
   }
 }

--- a/packages/protons/test/fixtures/circuit.proto
+++ b/packages/protons/test/fixtures/circuit.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+message CircuitRelay {
+
+  enum Status {
+    SUCCESS                    = 100;
+    HOP_SRC_ADDR_TOO_LONG      = 220;
+    HOP_DST_ADDR_TOO_LONG      = 221;
+    HOP_SRC_MULTIADDR_INVALID  = 250;
+    HOP_DST_MULTIADDR_INVALID  = 251;
+    HOP_NO_CONN_TO_DST         = 260;
+    HOP_CANT_DIAL_DST          = 261;
+    HOP_CANT_OPEN_DST_STREAM   = 262;
+    HOP_CANT_SPEAK_RELAY       = 270;
+    HOP_CANT_RELAY_TO_SELF     = 280;
+    STOP_SRC_ADDR_TOO_LONG     = 320;
+    STOP_DST_ADDR_TOO_LONG     = 321;
+    STOP_SRC_MULTIADDR_INVALID = 350;
+    STOP_DST_MULTIADDR_INVALID = 351;
+    STOP_RELAY_REFUSED         = 390;
+    MALFORMED_MESSAGE          = 400;
+  }
+
+  enum Type { // RPC identifier, either HOP, STOP or STATUS
+    HOP = 1;
+    STOP = 2;
+    STATUS = 3;
+    CAN_HOP = 4;
+  }
+
+  message Peer {
+    required bytes id = 1;    // peer id
+    repeated bytes addrs = 2; // peer's known addresses
+  }
+
+  optional Type type = 1;     // Type of the message
+
+  optional Peer srcPeer = 2;  // srcPeer and dstPeer are used when Type is HOP or STATUS
+  optional Peer dstPeer = 3;
+
+  optional Status code = 4;   // Status code, used when Type is STATUS
+}

--- a/packages/protons/test/fixtures/circuit.ts
+++ b/packages/protons/test/fixtures/circuit.ts
@@ -1,0 +1,91 @@
+/* eslint-disable import/export */
+/* eslint-disable @typescript-eslint/no-namespace */
+
+import { enumeration, encodeMessage, decodeMessage, message, bytes } from 'protons-runtime'
+import type { Codec } from 'protons-runtime'
+
+export interface CircuitRelay {
+  type?: CircuitRelay.Type
+  srcPeer?: CircuitRelay.Peer
+  dstPeer?: CircuitRelay.Peer
+  code?: CircuitRelay.Status
+}
+
+export namespace CircuitRelay {
+  export enum Status {
+    SUCCESS = 'SUCCESS',
+    HOP_SRC_ADDR_TOO_LONG = 'HOP_SRC_ADDR_TOO_LONG',
+    HOP_DST_ADDR_TOO_LONG = 'HOP_DST_ADDR_TOO_LONG',
+    HOP_SRC_MULTIADDR_INVALID = 'HOP_SRC_MULTIADDR_INVALID',
+    HOP_DST_MULTIADDR_INVALID = 'HOP_DST_MULTIADDR_INVALID',
+    HOP_NO_CONN_TO_DST = 'HOP_NO_CONN_TO_DST',
+    HOP_CANT_DIAL_DST = 'HOP_CANT_DIAL_DST',
+    HOP_CANT_OPEN_DST_STREAM = 'HOP_CANT_OPEN_DST_STREAM',
+    HOP_CANT_SPEAK_RELAY = 'HOP_CANT_SPEAK_RELAY',
+    HOP_CANT_RELAY_TO_SELF = 'HOP_CANT_RELAY_TO_SELF',
+    STOP_SRC_ADDR_TOO_LONG = 'STOP_SRC_ADDR_TOO_LONG',
+    STOP_DST_ADDR_TOO_LONG = 'STOP_DST_ADDR_TOO_LONG',
+    STOP_SRC_MULTIADDR_INVALID = 'STOP_SRC_MULTIADDR_INVALID',
+    STOP_DST_MULTIADDR_INVALID = 'STOP_DST_MULTIADDR_INVALID',
+    STOP_RELAY_REFUSED = 'STOP_RELAY_REFUSED',
+    MALFORMED_MESSAGE = 'MALFORMED_MESSAGE'
+  }
+
+  export namespace Status {
+    export const codec = () => {
+      return enumeration<typeof Status>(Status)
+    }
+  }
+
+  export enum Type {
+    HOP = 'HOP',
+    STOP = 'STOP',
+    STATUS = 'STATUS',
+    CAN_HOP = 'CAN_HOP'
+  }
+
+  export namespace Type {
+    export const codec = () => {
+      return enumeration<typeof Type>(Type)
+    }
+  }
+
+  export interface Peer {
+    id: Uint8Array
+    addrs: Uint8Array[]
+  }
+
+  export namespace Peer {
+    export const codec = (): Codec<Peer> => {
+      return message<Peer>({
+        1: { name: 'id', codec: bytes },
+        2: { name: 'addrs', codec: bytes, repeats: true }
+      })
+    }
+
+    export const encode = (obj: Peer): Uint8Array => {
+      return encodeMessage(obj, Peer.codec())
+    }
+
+    export const decode = (buf: Uint8Array): Peer => {
+      return decodeMessage(buf, Peer.codec())
+    }
+  }
+
+  export const codec = (): Codec<CircuitRelay> => {
+    return message<CircuitRelay>({
+      1: { name: 'type', codec: CircuitRelay.Type.codec(), optional: true },
+      2: { name: 'srcPeer', codec: CircuitRelay.Peer.codec(), optional: true },
+      3: { name: 'dstPeer', codec: CircuitRelay.Peer.codec(), optional: true },
+      4: { name: 'code', codec: CircuitRelay.Status.codec(), optional: true }
+    })
+  }
+
+  export const encode = (obj: CircuitRelay): Uint8Array => {
+    return encodeMessage(obj, CircuitRelay.codec())
+  }
+
+  export const decode = (buf: Uint8Array): CircuitRelay => {
+    return decodeMessage(buf, CircuitRelay.codec())
+  }
+}

--- a/packages/protons/test/fixtures/daemon.ts
+++ b/packages/protons/test/fixtures/daemon.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 
 import { enumeration, encodeMessage, decodeMessage, message, bytes, int64, string, int32 } from 'protons-runtime'
+import type { Codec } from 'protons-runtime'
 
 export interface Request {
   type: Request.Type
@@ -35,7 +36,7 @@ export namespace Request {
     }
   }
 
-  export const codec = () => {
+  export const codec = (): Codec<Request> => {
     return message<Request>({
       1: { name: 'type', codec: Request.Type.codec() },
       2: { name: 'connect', codec: ConnectRequest.codec(), optional: true },
@@ -81,7 +82,7 @@ export namespace Response {
     }
   }
 
-  export const codec = () => {
+  export const codec = (): Codec<Response> => {
     return message<Response>({
       1: { name: 'type', codec: Response.Type.codec() },
       2: { name: 'error', codec: ErrorResponse.codec(), optional: true },
@@ -109,7 +110,7 @@ export interface IdentifyResponse {
 }
 
 export namespace IdentifyResponse {
-  export const codec = () => {
+  export const codec = (): Codec<IdentifyResponse> => {
     return message<IdentifyResponse>({
       1: { name: 'id', codec: bytes },
       2: { name: 'addrs', codec: bytes, repeats: true }
@@ -132,7 +133,7 @@ export interface ConnectRequest {
 }
 
 export namespace ConnectRequest {
-  export const codec = () => {
+  export const codec = (): Codec<ConnectRequest> => {
     return message<ConnectRequest>({
       1: { name: 'peer', codec: bytes },
       2: { name: 'addrs', codec: bytes, repeats: true },
@@ -156,7 +157,7 @@ export interface StreamOpenRequest {
 }
 
 export namespace StreamOpenRequest {
-  export const codec = () => {
+  export const codec = (): Codec<StreamOpenRequest> => {
     return message<StreamOpenRequest>({
       1: { name: 'peer', codec: bytes },
       2: { name: 'proto', codec: string, repeats: true },
@@ -179,7 +180,7 @@ export interface StreamHandlerRequest {
 }
 
 export namespace StreamHandlerRequest {
-  export const codec = () => {
+  export const codec = (): Codec<StreamHandlerRequest> => {
     return message<StreamHandlerRequest>({
       1: { name: 'addr', codec: bytes },
       2: { name: 'proto', codec: string, repeats: true }
@@ -200,7 +201,7 @@ export interface ErrorResponse {
 }
 
 export namespace ErrorResponse {
-  export const codec = () => {
+  export const codec = (): Codec<ErrorResponse> => {
     return message<ErrorResponse>({
       1: { name: 'msg', codec: string }
     })
@@ -222,7 +223,7 @@ export interface StreamInfo {
 }
 
 export namespace StreamInfo {
-  export const codec = () => {
+  export const codec = (): Codec<StreamInfo> => {
     return message<StreamInfo>({
       1: { name: 'peer', codec: bytes },
       2: { name: 'addr', codec: bytes },
@@ -268,7 +269,7 @@ export namespace DHTRequest {
     }
   }
 
-  export const codec = () => {
+  export const codec = (): Codec<DHTRequest> => {
     return message<DHTRequest>({
       1: { name: 'type', codec: DHTRequest.Type.codec() },
       2: { name: 'peer', codec: bytes, optional: true },
@@ -308,7 +309,7 @@ export namespace DHTResponse {
     }
   }
 
-  export const codec = () => {
+  export const codec = (): Codec<DHTResponse> => {
     return message<DHTResponse>({
       1: { name: 'type', codec: DHTResponse.Type.codec() },
       2: { name: 'peer', codec: PeerInfo.codec(), optional: true },
@@ -331,7 +332,7 @@ export interface PeerInfo {
 }
 
 export namespace PeerInfo {
-  export const codec = () => {
+  export const codec = (): Codec<PeerInfo> => {
     return message<PeerInfo>({
       1: { name: 'id', codec: bytes },
       2: { name: 'addrs', codec: bytes, repeats: true }
@@ -367,7 +368,7 @@ export namespace ConnManagerRequest {
     }
   }
 
-  export const codec = () => {
+  export const codec = (): Codec<ConnManagerRequest> => {
     return message<ConnManagerRequest>({
       1: { name: 'type', codec: ConnManagerRequest.Type.codec() },
       2: { name: 'peer', codec: bytes, optional: true },
@@ -390,7 +391,7 @@ export interface DisconnectRequest {
 }
 
 export namespace DisconnectRequest {
-  export const codec = () => {
+  export const codec = (): Codec<DisconnectRequest> => {
     return message<DisconnectRequest>({
       1: { name: 'peer', codec: bytes }
     })
@@ -425,7 +426,7 @@ export namespace PSRequest {
     }
   }
 
-  export const codec = () => {
+  export const codec = (): Codec<PSRequest> => {
     return message<PSRequest>({
       1: { name: 'type', codec: PSRequest.Type.codec() },
       2: { name: 'topic', codec: string, optional: true },
@@ -452,7 +453,7 @@ export interface PSMessage {
 }
 
 export namespace PSMessage {
-  export const codec = () => {
+  export const codec = (): Codec<PSMessage> => {
     return message<PSMessage>({
       1: { name: 'from', codec: bytes, optional: true },
       2: { name: 'data', codec: bytes, optional: true },
@@ -478,7 +479,7 @@ export interface PSResponse {
 }
 
 export namespace PSResponse {
-  export const codec = () => {
+  export const codec = (): Codec<PSResponse> => {
     return message<PSResponse>({
       1: { name: 'topics', codec: string, repeats: true },
       2: { name: 'peerIDs', codec: bytes, repeats: true }
@@ -512,7 +513,7 @@ export namespace PeerstoreRequest {
     }
   }
 
-  export const codec = () => {
+  export const codec = (): Codec<PeerstoreRequest> => {
     return message<PeerstoreRequest>({
       1: { name: 'type', codec: PeerstoreRequest.Type.codec() },
       2: { name: 'id', codec: bytes, optional: true },
@@ -535,7 +536,7 @@ export interface PeerstoreResponse {
 }
 
 export namespace PeerstoreResponse {
-  export const codec = () => {
+  export const codec = (): Codec<PeerstoreResponse> => {
     return message<PeerstoreResponse>({
       1: { name: 'peer', codec: PeerInfo.codec(), optional: true },
       2: { name: 'protos', codec: string, repeats: true }

--- a/packages/protons/test/fixtures/dht.ts
+++ b/packages/protons/test/fixtures/dht.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 
 import { encodeMessage, decodeMessage, message, bytes, string, enumeration, int32 } from 'protons-runtime'
+import type { Codec } from 'protons-runtime'
 
 export interface Record {
   key?: Uint8Array
@@ -12,20 +13,22 @@ export interface Record {
 }
 
 export namespace Record {
-  export const codec = message<Record>({
-    1: { name: 'key', codec: bytes, optional: true },
-    2: { name: 'value', codec: bytes, optional: true },
-    3: { name: 'author', codec: bytes, optional: true },
-    4: { name: 'signature', codec: bytes, optional: true },
-    5: { name: 'timeReceived', codec: string, optional: true }
-  })
+  export const codec = (): Codec<Record> => {
+    return message<Record>({
+      1: { name: 'key', codec: bytes, optional: true },
+      2: { name: 'value', codec: bytes, optional: true },
+      3: { name: 'author', codec: bytes, optional: true },
+      4: { name: 'signature', codec: bytes, optional: true },
+      5: { name: 'timeReceived', codec: string, optional: true }
+    })
+  }
 
   export const encode = (obj: Record): Uint8Array => {
-    return encodeMessage(obj, Record.codec)
+    return encodeMessage(obj, Record.codec())
   }
 
   export const decode = (buf: Uint8Array): Record => {
-    return decodeMessage(buf, Record.codec)
+    return decodeMessage(buf, Record.codec())
   }
 }
 
@@ -49,8 +52,11 @@ export namespace Message {
   }
 
   export namespace MessageType {
-    export const codec = enumeration<typeof MessageType>(MessageType)
+    export const codec = () => {
+      return enumeration<typeof MessageType>(MessageType)
+    }
   }
+
   export enum ConnectionType {
     NOT_CONNECTED = 'NOT_CONNECTED',
     CONNECTED = 'CONNECTED',
@@ -59,8 +65,11 @@ export namespace Message {
   }
 
   export namespace ConnectionType {
-    export const codec = enumeration<typeof ConnectionType>(ConnectionType)
+    export const codec = () => {
+      return enumeration<typeof ConnectionType>(ConnectionType)
+    }
   }
+
   export interface Peer {
     id?: Uint8Array
     addrs: Uint8Array[]
@@ -68,35 +77,39 @@ export namespace Message {
   }
 
   export namespace Peer {
-    export const codec = message<Peer>({
-      1: { name: 'id', codec: bytes, optional: true },
-      2: { name: 'addrs', codec: bytes, repeats: true },
-      3: { name: 'connection', codec: Message.ConnectionType.codec, optional: true }
-    })
+    export const codec = (): Codec<Peer> => {
+      return message<Peer>({
+        1: { name: 'id', codec: bytes, optional: true },
+        2: { name: 'addrs', codec: bytes, repeats: true },
+        3: { name: 'connection', codec: Message.ConnectionType.codec(), optional: true }
+      })
+    }
 
     export const encode = (obj: Peer): Uint8Array => {
-      return encodeMessage(obj, Peer.codec)
+      return encodeMessage(obj, Peer.codec())
     }
 
     export const decode = (buf: Uint8Array): Peer => {
-      return decodeMessage(buf, Peer.codec)
+      return decodeMessage(buf, Peer.codec())
     }
   }
 
-  export const codec = message<Message>({
-    1: { name: 'type', codec: Message.MessageType.codec, optional: true },
-    10: { name: 'clusterLevelRaw', codec: int32, optional: true },
-    2: { name: 'key', codec: bytes, optional: true },
-    3: { name: 'record', codec: bytes, optional: true },
-    8: { name: 'closerPeers', codec: Message.Peer.codec, repeats: true },
-    9: { name: 'providerPeers', codec: Message.Peer.codec, repeats: true }
-  })
+  export const codec = (): Codec<Message> => {
+    return message<Message>({
+      1: { name: 'type', codec: Message.MessageType.codec(), optional: true },
+      10: { name: 'clusterLevelRaw', codec: int32, optional: true },
+      2: { name: 'key', codec: bytes, optional: true },
+      3: { name: 'record', codec: bytes, optional: true },
+      8: { name: 'closerPeers', codec: Message.Peer.codec(), repeats: true },
+      9: { name: 'providerPeers', codec: Message.Peer.codec(), repeats: true }
+    })
+  }
 
   export const encode = (obj: Message): Uint8Array => {
-    return encodeMessage(obj, Message.codec)
+    return encodeMessage(obj, Message.codec())
   }
 
   export const decode = (buf: Uint8Array): Message => {
-    return decodeMessage(buf, Message.codec)
+    return decodeMessage(buf, Message.codec())
   }
 }

--- a/packages/protons/test/fixtures/noise.proto
+++ b/packages/protons/test/fixtures/noise.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package pb;
+
+message NoiseHandshakePayload {
+	bytes identity_key = 1;
+	bytes identity_sig = 2;
+	bytes data = 3;
+}

--- a/packages/protons/test/fixtures/noise.ts
+++ b/packages/protons/test/fixtures/noise.ts
@@ -1,0 +1,31 @@
+/* eslint-disable import/export */
+/* eslint-disable @typescript-eslint/no-namespace */
+
+import { encodeMessage, decodeMessage, message, bytes } from 'protons-runtime'
+import type { Codec } from 'protons-runtime'
+
+export namespace pb {
+  export interface NoiseHandshakePayload {
+    identityKey: Uint8Array
+    identitySig: Uint8Array
+    data: Uint8Array
+  }
+
+  export namespace NoiseHandshakePayload {
+    export const codec = (): Codec<NoiseHandshakePayload> => {
+      return message<NoiseHandshakePayload>({
+        1: { name: 'identityKey', codec: bytes },
+        2: { name: 'identitySig', codec: bytes },
+        3: { name: 'data', codec: bytes }
+      })
+    }
+
+    export const encode = (obj: NoiseHandshakePayload): Uint8Array => {
+      return encodeMessage(obj, NoiseHandshakePayload.codec())
+    }
+
+    export const decode = (buf: Uint8Array): NoiseHandshakePayload => {
+      return decodeMessage(buf, NoiseHandshakePayload.codec())
+    }
+  }
+}

--- a/packages/protons/test/fixtures/peer.ts
+++ b/packages/protons/test/fixtures/peer.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 
 import { encodeMessage, decodeMessage, message, string, bytes, bool } from 'protons-runtime'
+import type { Codec } from 'protons-runtime'
 
 export interface Peer {
   addresses: Address[]
@@ -12,7 +13,7 @@ export interface Peer {
 }
 
 export namespace Peer {
-  export const codec = () => {
+  export const codec = (): Codec<Peer> => {
     return message<Peer>({
       1: { name: 'addresses', codec: Address.codec(), repeats: true },
       2: { name: 'protocols', codec: string, repeats: true },
@@ -37,7 +38,7 @@ export interface Address {
 }
 
 export namespace Address {
-  export const codec = () => {
+  export const codec = (): Codec<Address> => {
     return message<Address>({
       1: { name: 'multiaddr', codec: bytes },
       2: { name: 'isCertified', codec: bool, optional: true }
@@ -59,7 +60,7 @@ export interface Metadata {
 }
 
 export namespace Metadata {
-  export const codec = () => {
+  export const codec = (): Codec<Metadata> => {
     return message<Metadata>({
       1: { name: 'key', codec: string },
       2: { name: 'value', codec: bytes }

--- a/packages/protons/test/fixtures/test.ts
+++ b/packages/protons/test/fixtures/test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 
 import { enumeration, encodeMessage, decodeMessage, message, string, bool, int32, int64, uint32, uint64, sint32, sint64, double, float, bytes, fixed32, fixed64, sfixed32, sfixed64 } from 'protons-runtime'
+import type { Codec } from 'protons-runtime'
 
 export enum AnEnum {
   HERP = 'HERP',
@@ -9,24 +10,27 @@ export enum AnEnum {
 }
 
 export namespace AnEnum {
-  export const codec = enumeration<typeof AnEnum>(AnEnum)
+  export const codec = () => {
+    return enumeration<typeof AnEnum>(AnEnum)
+  }
 }
-
 export interface SubMessage {
   foo: string
 }
 
 export namespace SubMessage {
-  export const codec = message<SubMessage>({
-    1: { name: 'foo', codec: string }
-  })
+  export const codec = (): Codec<SubMessage> => {
+    return message<SubMessage>({
+      1: { name: 'foo', codec: string }
+    })
+  }
 
   export const encode = (obj: SubMessage): Uint8Array => {
-    return encodeMessage(obj, SubMessage.codec)
+    return encodeMessage(obj, SubMessage.codec())
   }
 
   export const decode = (buf: Uint8Array): SubMessage => {
-    return decodeMessage(buf, SubMessage.codec)
+    return decodeMessage(buf, SubMessage.codec())
   }
 }
 
@@ -52,32 +56,34 @@ export interface AllTheTypes {
 }
 
 export namespace AllTheTypes {
-  export const codec = message<AllTheTypes>({
-    1: { name: 'field1', codec: bool, optional: true },
-    2: { name: 'field2', codec: int32, optional: true },
-    3: { name: 'field3', codec: int64, optional: true },
-    4: { name: 'field4', codec: uint32, optional: true },
-    5: { name: 'field5', codec: uint64, optional: true },
-    6: { name: 'field6', codec: sint32, optional: true },
-    7: { name: 'field7', codec: sint64, optional: true },
-    8: { name: 'field8', codec: double, optional: true },
-    9: { name: 'field9', codec: float, optional: true },
-    10: { name: 'field10', codec: string, optional: true },
-    11: { name: 'field11', codec: bytes, optional: true },
-    12: { name: 'field12', codec: AnEnum.codec, optional: true },
-    13: { name: 'field13', codec: SubMessage.codec, optional: true },
-    14: { name: 'field14', codec: string, repeats: true },
-    15: { name: 'field15', codec: fixed32, optional: true },
-    16: { name: 'field16', codec: fixed64, optional: true },
-    17: { name: 'field17', codec: sfixed32, optional: true },
-    18: { name: 'field18', codec: sfixed64, optional: true }
-  })
+  export const codec = (): Codec<AllTheTypes> => {
+    return message<AllTheTypes>({
+      1: { name: 'field1', codec: bool, optional: true },
+      2: { name: 'field2', codec: int32, optional: true },
+      3: { name: 'field3', codec: int64, optional: true },
+      4: { name: 'field4', codec: uint32, optional: true },
+      5: { name: 'field5', codec: uint64, optional: true },
+      6: { name: 'field6', codec: sint32, optional: true },
+      7: { name: 'field7', codec: sint64, optional: true },
+      8: { name: 'field8', codec: double, optional: true },
+      9: { name: 'field9', codec: float, optional: true },
+      10: { name: 'field10', codec: string, optional: true },
+      11: { name: 'field11', codec: bytes, optional: true },
+      12: { name: 'field12', codec: AnEnum.codec(), optional: true },
+      13: { name: 'field13', codec: SubMessage.codec(), optional: true },
+      14: { name: 'field14', codec: string, repeats: true },
+      15: { name: 'field15', codec: fixed32, optional: true },
+      16: { name: 'field16', codec: fixed64, optional: true },
+      17: { name: 'field17', codec: sfixed32, optional: true },
+      18: { name: 'field18', codec: sfixed64, optional: true }
+    })
+  }
 
   export const encode = (obj: AllTheTypes): Uint8Array => {
-    return encodeMessage(obj, AllTheTypes.codec)
+    return encodeMessage(obj, AllTheTypes.codec())
   }
 
   export const decode = (buf: Uint8Array): AllTheTypes => {
-    return decodeMessage(buf, AllTheTypes.codec)
+    return decodeMessage(buf, AllTheTypes.codec())
   }
 }


### PR DESCRIPTION
When generating code, if a namespace doesn't have any fields, don't declare an interface for it as it fails some linting checks.

Also, declare the return type of generated codec methods as we know it and it's a linting issue for some setups.