### PR TITLE
fix: single instance codec

### DIFF
--- a/packages/protons/src/index.ts
+++ b/packages/protons/src/index.ts
@@ -189,8 +189,9 @@ export interface ${messageDef.name} {
   }
 }`
     interfaceCodecDef = `
+  let _codec: Codec<${messageDef.name}>
   export const codec = (): Codec<${messageDef.name}> => {
-    return message<${messageDef.name}>({
+    if (!_codec) _codec = message<${messageDef.name}>({
       ${Object.entries(fields)
       .map(([name, fieldDef]) => {
         let codec = encoders[fieldDef.type]
@@ -213,6 +214,7 @@ export interface ${messageDef.name} {
         return `${fieldDef.id}: { name: '${name}', codec: ${codec}${fieldDef.options?.proto3_optional === true ? ', optional: true' : ''}${fieldDef.rule === 'repeated' ? ', repeats: true' : ''} }`
     }).join(',\n      ')}
     })
+    return _codec
   }
 
   export const encode = (obj: ${messageDef.name}): Uint8Array => {


### PR DESCRIPTION
**Motivation**
- Right now every time we call `encode()` or `decode()`, a new codec is returned, it also create other codecs of internal fields

**Description**
- Generate the `codec()` function using single instance pattern

part of #51 