### PR TITLE
fix: add uint8arraylist peer dep

### DIFF
--- a/packages/protons-runtime/package.json
+++ b/packages/protons-runtime/package.json
@@ -151,6 +151,9 @@
     "protobufjs": "^7.0.0",
     "uint8arraylist": "^2.3.2"
   },
+  "peerDependencies": {
+    "uint8arraylist": "^2.3.2"
+  },
   "devDependencies": {
     "aegir": "^37.0.5"
   }


### PR DESCRIPTION
The code generated by protons references the `uint8arraylist` module.

To ensure consumers have that module available, add `uint8arraylist` as a peer dep of `protons-runtime`.

Fixes #59