### PR TITLE
Write buffer when Enum field  value is 0 

### DIFF
--- a/packages/protons/src/index.ts
+++ b/packages/protons/src/index.ts
@@ -402,7 +402,7 @@ ${Object.entries(fields)
             valueTest = `opts.writeDefaults === true || ${defaultValueTestGenerators[type](`obj.${name}`)}`
           } else if (type === 'enum') {
             // handle enums
-            valueTest = `opts.writeDefaults === true || (obj.${name} != null && __${fieldDef.type}Values[obj.${name}] !== 0)`
+            valueTest = `opts.writeDefaults === true || (obj.${name} != null )`
           }
         }
 


### PR DESCRIPTION
Something wrong when type filed value is RESERVE, like the proto below: 

message HopMessage {
  enum Type {
    RESERVE = 0;
    CONNECT = 1;
    STATUS = 2;
  }

  required Type type = 1;

  optional Peer peer = 2;
  optional Reservation reservation = 3;
  optional Limit limit = 4;

  optional Status status = 5;
}
