### PR TITLE
fix: throw when unsupported fields are detected

### DIFF
--- a/packages/protons-benchmark/src/decode.ts
+++ b/packages/protons-benchmark/src/decode.ts
@@ -44,7 +44,7 @@ new Benchmark.Suite()
   })
   .on('complete', function () {
     // @ts-expect-error types are wrong
-    console.info(`Fastest is ${this.filter('fastest').map('name')}`) // eslint-disable-line @typescript-eslint/restrict-template-expressions
+    console.info(`Fastest is ${this.filter('fastest').map('name')}`)
   })
   // run async
   .run({ async: true })

--- a/packages/protons-benchmark/src/encode.ts
+++ b/packages/protons-benchmark/src/encode.ts
@@ -42,7 +42,7 @@ new Benchmark.Suite()
   })
   .on('complete', function () {
     // @ts-expect-error types are wrong
-    console.info(`Fastest is ${this.filter('fastest').map('name')}`) // eslint-disable-line @typescript-eslint/restrict-template-expressions
+    console.info(`Fastest is ${this.filter('fastest').map('name')}`)
   })
   // run async
   .run({ async: true })

--- a/packages/protons-benchmark/src/index.ts
+++ b/packages/protons-benchmark/src/index.ts
@@ -67,7 +67,7 @@ new Benchmark.Suite()
   })
   .on('complete', function () {
     // @ts-expect-error types are wrong
-    console.info(`Fastest is ${this.filter('fastest').map('name')}`) // eslint-disable-line @typescript-eslint/restrict-template-expressions
+    console.info(`Fastest is ${this.filter('fastest').map('name')}`)
   })
   // run async
   .run({ async: true })

--- a/packages/protons-benchmark/src/rpc.ts
+++ b/packages/protons-benchmark/src/rpc.ts
@@ -43,7 +43,7 @@ new Benchmark.Suite()
   })
   .on('complete', function () {
     // @ts-expect-error types are wrong
-    console.info(`Fastest is ${this.filter('fastest').map('name')}`) // eslint-disable-line @typescript-eslint/restrict-template-expressions
+    console.info(`Fastest is ${this.filter('fastest').map('name')}`)
   })
   // run async
   .run({ async: true })

--- a/packages/protons/package.json
+++ b/packages/protons/package.json
@@ -158,7 +158,6 @@
   },
   "devDependencies": {
     "aegir": "^38.0.0",
-    "execa": "^6.1.0",
     "long": "^5.2.0",
     "pbjs": "^0.0.14",
     "protobufjs": "^7.0.0",

--- a/packages/protons/package.json
+++ b/packages/protons/package.json
@@ -158,11 +158,11 @@
   },
   "devDependencies": {
     "aegir": "^38.0.0",
+    "execa": "^6.1.0",
     "long": "^5.2.0",
     "pbjs": "^0.0.14",
     "protobufjs": "^7.0.0",
     "protons-runtime": "^4.0.0",
-    "uint8arraylist": "^2.3.2",
-    "uint8arrays": "^4.0.2"
+    "uint8arraylist": "^2.3.2"
   }
 }

--- a/packages/protons/src/index.ts
+++ b/packages/protons/src/index.ts
@@ -595,6 +595,10 @@ function defineModule (def: ClassDef): ModuleDef {
           fieldDef.repeated = fieldDef.rule === 'repeated'
           fieldDef.optional = !fieldDef.repeated && fieldDef.options?.proto3_optional === true
           fieldDef.map = fieldDef.keyType != null
+
+          if (fieldDef.rule === 'required') {
+            throw new Error('"required" fields are not allowed in proto3 - please convert your proto2 definitions to proto3')
+          }
         }
       }
 

--- a/packages/protons/test/fixtures/proto2.proto
+++ b/packages/protons/test/fixtures/proto2.proto
@@ -1,0 +1,5 @@
+syntax = "proto2";
+
+message Message {
+  required string requiredField = 1;
+}

--- a/packages/protons/test/index.spec.ts
+++ b/packages/protons/test/index.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-env mocha */
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 
 import { expect } from 'aegir/chai'
 import pbjs from 'pbjs'

--- a/packages/protons/test/maps.spec.ts
+++ b/packages/protons/test/maps.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-env mocha */
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 
 import { expect } from 'aegir/chai'
 import { MapTypes, SubMessage } from './fixtures/maps.js'

--- a/packages/protons/test/unsupported.spec.ts
+++ b/packages/protons/test/unsupported.spec.ts
@@ -1,0 +1,12 @@
+/* eslint-env mocha */
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+
+import { expect } from 'aegir/chai'
+import { execa } from 'execa'
+
+describe('unsupported', () => {
+  it('should refuse to generate source from proto2 definition', async () => {
+    await expect(execa('dist/bin/protons.js', ['./test/fixtures/proto2.proto'])).to.eventually.be.rejected()
+      .with.property('stderr').that.contain('"required" fields are not allowed in proto3')
+  })
+})

--- a/packages/protons/test/unsupported.spec.ts
+++ b/packages/protons/test/unsupported.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-env mocha */
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 
 import { expect } from 'aegir/chai'
 import { execa } from 'execa'

--- a/packages/protons/test/unsupported.spec.ts
+++ b/packages/protons/test/unsupported.spec.ts
@@ -1,11 +1,11 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
-import { execa } from 'execa'
+import { generate } from '../src/index.js'
 
 describe('unsupported', () => {
   it('should refuse to generate source from proto2 definition', async () => {
-    await expect(execa('dist/bin/protons.js', ['./test/fixtures/proto2.proto'])).to.eventually.be.rejected()
-      .with.property('stderr').that.contain('"required" fields are not allowed in proto3')
+    await expect(generate('test/fixtures/proto2.proto', {})).to.eventually.be.rejected
+      .with.property('message').that.contain('"required" fields are not allowed in proto3')
   })
 })


### PR DESCRIPTION
`required` is a field in proto2 but not in proto3 so throw if it is encountered while generating `.ts` from `.proto`.

It would be better to detect `proto2` from the `syntax` directive but it's not in the output of the `pbjs -t json` command.

Fixes #34