### PR TITLE
fix: throw when .proto is empty

### DIFF
--- a/packages/protons/src/index.ts
+++ b/packages/protons/src/index.ts
@@ -655,7 +655,7 @@ export async function generate (source: string, flags: Flags): Promise<void> {
 
   const def = JSON.parse(json)
 
-  for (const [className, classDef] of Object.entries<any>(def.nested)) {
+  for (const [className, classDef] of Object.entries<any>(def.nested ?? {})) {
     for (const [fieldName, fieldDef] of Object.entries<any>(classDef.fields ?? {})) {
       if (fieldDef.keyType == null) {
         continue

--- a/packages/protons/test/unsupported.spec.ts
+++ b/packages/protons/test/unsupported.spec.ts
@@ -8,4 +8,9 @@ describe('unsupported', () => {
     await expect(generate('test/fixtures/proto2.proto', {})).to.eventually.be.rejected
       .with.property('message').that.contain('"required" fields are not allowed in proto3')
   })
+
+  it('should refuse to generate source from empty definition', async () => {
+    await expect(generate('test/fixtures/empty.proto', {})).to.eventually.be.rejected
+      .with.property('message').that.contain('No top-level messages found in protobuf')
+  })
 })


### PR DESCRIPTION
Refuse to compile an empty .proto file