### PR TITLE
fix: sort imports

### DIFF
--- a/packages/protons-benchmark/src/decode.ts
+++ b/packages/protons-benchmark/src/decode.ts
@@ -6,9 +6,10 @@ $ npx playwright-test dist/src/index.js --runner benchmark
 */
 
 import Benchmark from 'benchmark'
-import { Test as ProtonsTest } from './protons/bench.js'
+
 import { decodeTest as pbjsDecodeTest } from './pbjs/bench.js'
 import { Test as ProtobufjsTest } from './protobufjs/bench.js'
+import { Test as ProtonsTest } from './protons/bench.js'
 
 const message = {
   meh: {

--- a/packages/protons-benchmark/src/encode.ts
+++ b/packages/protons-benchmark/src/encode.ts
@@ -6,9 +6,10 @@ $ npx playwright-test dist/src/index.js --runner benchmark
 */
 
 import Benchmark from 'benchmark'
-import { Test as ProtonsTest } from './protons/bench.js'
+
 import { encodeTest as pbjsEncodeTest } from './pbjs/bench.js'
 import { Test as ProtobufjsTest } from './protobufjs/bench.js'
+import { Test as ProtonsTest } from './protons/bench.js'
 
 const message = {
   meh: {

--- a/packages/protons-benchmark/src/index.ts
+++ b/packages/protons-benchmark/src/index.ts
@@ -5,12 +5,14 @@ $ node dist/src/index.js
 $ npx playwright-test dist/src/index.js --runner benchmark
 */
 
-import Benchmark from 'benchmark'
 import { expect } from 'aegir/chai'
-import { Test as ProtonsTest } from './protons/bench.js'
+
+import Benchmark from 'benchmark'
+
 import { encodeTest as pbjsEncodeTest, decodeTest as pbjsDecodeTest } from './pbjs/bench.js'
-import { Test as ProtobufjsTest } from './protobufjs/bench.js'
 import { Test as ProtobufTsTest } from './protobuf-ts/bench.js'
+import { Test as ProtobufjsTest } from './protobufjs/bench.js'
+import { Test as ProtonsTest } from './protons/bench.js'
 
 const message = {
   meh: {

--- a/packages/protons-benchmark/src/protons/bench.ts
+++ b/packages/protons-benchmark/src/protons/bench.ts
@@ -4,8 +4,8 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 
 import { encodeMessage, decodeMessage, message, enumeration } from 'protons-runtime'
-import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface Foo {
   baz?: number

--- a/packages/protons-benchmark/src/protons/rpc.ts
+++ b/packages/protons-benchmark/src/protons/rpc.ts
@@ -4,8 +4,8 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 
 import { encodeMessage, decodeMessage, message, writer } from 'protons-runtime'
-import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface RPC {
   subscriptions: RPC.SubOpts[]

--- a/packages/protons-benchmark/src/rpc.ts
+++ b/packages/protons-benchmark/src/rpc.ts
@@ -5,10 +5,12 @@ $ node dist/src/index.js
 $ npx playwright-test dist/src/index.js --runner benchmark
 */
 
-import Benchmark from 'benchmark'
-import { RPC as ProtonsRPC } from './protons/rpc.js'
-import { RPC as ProtobufjsRPC } from './protobufjs/rpc.js'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+
+import Benchmark from 'benchmark'
+
+import { RPC as ProtobufjsRPC } from './protobufjs/rpc.js'
+import { RPC as ProtonsRPC } from './protons/rpc.js'
 
 const rpc = {
   subscriptions: [],

--- a/packages/protons-runtime/src/decode.ts
+++ b/packages/protons-runtime/src/decode.ts
@@ -1,4 +1,5 @@
 import type { Uint8ArrayList } from 'uint8arraylist'
+
 import type { Codec } from './codec.js'
 import { reader } from './utils.js'
 

--- a/packages/protons-runtime/src/utils.ts
+++ b/packages/protons-runtime/src/utils.ts
@@ -3,11 +3,12 @@ import ReaderClass from 'protobufjs/src/reader.js'
 // @ts-expect-error no types
 import ReaderBufferClass from 'protobufjs/src/reader_buffer.js'
 // @ts-expect-error no types
+import util from 'protobufjs/src/util/minimal.js'
+// @ts-expect-error no types
 import WriterClass from 'protobufjs/src/writer.js'
 // @ts-expect-error no types
 import WriterBufferClass from 'protobufjs/src/writer_buffer.js'
-// @ts-expect-error no types
-import util from 'protobufjs/src/util/minimal.js'
+
 import type { Reader, Writer } from './index.js'
 
 function configure (): void {

--- a/packages/protons/bin/protons.ts
+++ b/packages/protons/bin/protons.ts
@@ -1,6 +1,7 @@
 #! /usr/bin/env node
 
 import meow from 'meow'
+
 import { generate } from '../src/index.js'
 
 async function main (): Promise<void> {

--- a/packages/protons/src/index.ts
+++ b/packages/protons/src/index.ts
@@ -1,9 +1,10 @@
 /* eslint-disable max-depth */
 
-import { main as pbjs } from 'protobufjs-cli/pbjs.js'
+import fs from 'fs/promises'
 import path from 'path'
 import { promisify } from 'util'
-import fs from 'fs/promises'
+
+import { main as pbjs } from 'protobufjs-cli/pbjs.js'
 
 export enum CODEC_TYPES {
   VARINT = 0,
@@ -686,29 +687,37 @@ export async function generate (source: string, flags: Flags): Promise<void> {
 
   const moduleDef = defineModule(def)
 
-  let lines = [
+  const ignores = [
     '/* eslint-disable import/export */',
     '/* eslint-disable complexity */',
     '/* eslint-disable @typescript-eslint/no-namespace */',
     '/* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */',
-    '/* eslint-disable @typescript-eslint/no-empty-interface */',
-    ''
+    '/* eslint-disable @typescript-eslint/no-empty-interface */'
   ]
 
+  const imports = []
+
   if (moduleDef.imports.size > 0) {
-    lines.push(`import { ${Array.from(moduleDef.imports).join(', ')} } from 'protons-runtime'`)
+    imports.push(`import { ${Array.from(moduleDef.imports).join(', ')} } from 'protons-runtime'`)
   }
 
   if (moduleDef.imports.has('encodeMessage')) {
-    lines.push("import type { Uint8ArrayList } from 'uint8arraylist'")
+    imports.push("import type { Uint8ArrayList } from 'uint8arraylist'")
   }
 
   if (moduleDef.importedTypes.size > 0) {
-    lines.push(`import type { ${Array.from(moduleDef.importedTypes).join(', ')} } from 'protons-runtime'`)
+    imports.push(`import type { ${Array.from(moduleDef.importedTypes).join(', ')} } from 'protons-runtime'`)
   }
 
-  lines = [
-    ...lines,
+  const lines = [
+    ...ignores,
+    '',
+    ...imports.sort((a, b) => {
+      const aModule = a.split("from '")[1].toString()
+      const bModule = b.split("from '")[1].toString()
+
+      return aModule.localeCompare(bModule)
+    }),
     '',
     ...moduleDef.compiled
   ]

--- a/packages/protons/test/fixtures/basic.ts
+++ b/packages/protons/test/fixtures/basic.ts
@@ -5,8 +5,8 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import { encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface Basic {
   foo?: string

--- a/packages/protons/test/fixtures/circuit.ts
+++ b/packages/protons/test/fixtures/circuit.ts
@@ -5,8 +5,8 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import { enumeration, encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface CircuitRelay {
   type?: CircuitRelay.Type

--- a/packages/protons/test/fixtures/daemon.ts
+++ b/packages/protons/test/fixtures/daemon.ts
@@ -5,8 +5,8 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import { enumeration, encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface Request {
   type: Request.Type

--- a/packages/protons/test/fixtures/dht.ts
+++ b/packages/protons/test/fixtures/dht.ts
@@ -5,8 +5,8 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import { encodeMessage, decodeMessage, message, enumeration } from 'protons-runtime'
-import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface Record {
   key?: Uint8Array

--- a/packages/protons/test/fixtures/maps.ts
+++ b/packages/protons/test/fixtures/maps.ts
@@ -5,8 +5,8 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import { encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface SubMessage {
   foo: string

--- a/packages/protons/test/fixtures/noise.ts
+++ b/packages/protons/test/fixtures/noise.ts
@@ -5,8 +5,8 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import { encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface pb {}
 

--- a/packages/protons/test/fixtures/optional.ts
+++ b/packages/protons/test/fixtures/optional.ts
@@ -5,8 +5,8 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import { enumeration, encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export enum OptionalEnum {
   NO_VALUE = 'NO_VALUE',

--- a/packages/protons/test/fixtures/peer.ts
+++ b/packages/protons/test/fixtures/peer.ts
@@ -5,8 +5,8 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import { encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface Peer {
   addresses: Address[]

--- a/packages/protons/test/fixtures/singular.ts
+++ b/packages/protons/test/fixtures/singular.ts
@@ -5,8 +5,8 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import { enumeration, encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export enum SingularEnum {
   NO_VALUE = 'NO_VALUE',

--- a/packages/protons/test/fixtures/test.ts
+++ b/packages/protons/test/fixtures/test.ts
@@ -5,8 +5,8 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import { enumeration, encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
 export enum AnEnum {
   HERP = 'HERP',

--- a/packages/protons/test/index.spec.ts
+++ b/packages/protons/test/index.spec.ts
@@ -1,16 +1,19 @@
 /* eslint-env mocha */
 
-import { expect } from 'aegir/chai'
-import pbjs from 'pbjs'
-import { Basic, Empty } from './fixtures/basic.js'
-import { AllTheTypes, AnEnum } from './fixtures/test.js'
 import fs from 'fs'
-import protobufjs, { Type as PBType } from 'protobufjs'
-import { Peer } from './fixtures/peer.js'
-import { CircuitRelay } from './fixtures/circuit.js'
+
+import { expect } from 'aegir/chai'
+
 import Long from 'long'
+import pbjs from 'pbjs'
+import protobufjs, { Type as PBType } from 'protobufjs'
+
+import { Basic, Empty } from './fixtures/basic.js'
+import { CircuitRelay } from './fixtures/circuit.js'
 import { Optional, OptionalEnum } from './fixtures/optional.js'
+import { Peer } from './fixtures/peer.js'
 import { Singular, SingularEnum } from './fixtures/singular.js'
+import { AllTheTypes, AnEnum } from './fixtures/test.js'
 
 function longifyBigInts (obj: any): any {
   const output = {

--- a/packages/protons/test/maps.spec.ts
+++ b/packages/protons/test/maps.spec.ts
@@ -1,9 +1,11 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
-import { MapTypes, SubMessage } from './fixtures/maps.js'
-import protobufjs from 'protobufjs'
+
 import Long from 'long'
+import protobufjs from 'protobufjs'
+
+import { MapTypes, SubMessage } from './fixtures/maps.js'
 
 function longifyBigInts (obj: any): any {
   const output = {

--- a/packages/protons/test/unsupported.spec.ts
+++ b/packages/protons/test/unsupported.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
+
 import { generate } from '../src/index.js'
 
 describe('unsupported', () => {


### PR DESCRIPTION
https://github.com/ipfs/eslint-config-ipfs/pull/126 will introduce linting rules on import sorting so order imports during building in a way that will comply with the new linting rules.