### PR TITLE
fix: treat nested enums as enums and not messages

### DIFF
--- a/packages/protons/test/fixtures/bitswap.proto
+++ b/packages/protons/test/fixtures/bitswap.proto
@@ -1,0 +1,43 @@
+// from https://github.com/ipfs/go-bitswap/blob/master/message/pb/message.proto
+syntax = "proto3";
+
+message Message {
+
+  message Wantlist {
+    enum WantType {
+      Block = 0;
+      Have = 1;
+    }
+
+    message Entry {
+      bytes block = 1;           // the block cid (cidV0 in bitswap 1.0.0, cidV1 in bitswap 1.1.0)
+      int32 priority = 2;        // the priority (normalized). default to 1
+      optional bool cancel = 3;           // whether this revokes an entry
+      WantType wantType = 4;     // Note: defaults to enum 0, ie Block
+      bool sendDontHave = 5;     // Note: defaults to false
+    }
+
+    repeated Entry entries = 1;  // a list of wantlist entries
+    bool full = 2;               // whether this is the full wantlist. default to false
+  }
+
+  message Block {
+    bytes prefix = 1;            // CID prefix (cid version, multicodec and multihash prefix (type + length)
+    bytes data = 2;
+  }
+
+  enum BlockPresenceType {
+    Have = 0;
+    DontHave = 1;
+  }
+  message BlockPresence {
+    bytes cid = 1;
+    BlockPresenceType type = 2;
+  }
+
+  Wantlist wantlist = 1;
+  repeated bytes blocks = 2;     // used to send Blocks in bitswap 1.0.0
+  repeated Block payload = 3;    // used to send Blocks in bitswap 1.1.0
+  repeated BlockPresence blockPresences = 4;
+  int32 pendingBytes = 5;
+}

--- a/packages/protons/test/fixtures/bitswap.ts
+++ b/packages/protons/test/fixtures/bitswap.ts
@@ -1,0 +1,447 @@
+/* eslint-disable import/export */
+/* eslint-disable complexity */
+/* eslint-disable @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
+/* eslint-disable @typescript-eslint/no-empty-interface */
+
+import { enumeration, encodeMessage, decodeMessage, message } from 'protons-runtime'
+import type { Codec } from 'protons-runtime'
+import type { Uint8ArrayList } from 'uint8arraylist'
+
+export interface Message {
+  wantlist?: Message.Wantlist
+  blocks: Uint8Array[]
+  payload: Message.Block[]
+  blockPresences: Message.BlockPresence[]
+  pendingBytes: number
+}
+
+export namespace Message {
+  export interface Wantlist {
+    entries: Message.Wantlist.Entry[]
+    full: boolean
+  }
+
+  export namespace Wantlist {
+    export enum WantType {
+      Block = 'Block',
+      Have = 'Have'
+    }
+
+    enum __WantTypeValues {
+      Block = 0,
+      Have = 1
+    }
+
+    export namespace WantType {
+      export const codec = (): Codec<WantType> => {
+        return enumeration<WantType>(__WantTypeValues)
+      }
+    }
+
+    export interface Entry {
+      block: Uint8Array
+      priority: number
+      cancel?: boolean
+      wantType: Message.Wantlist.WantType
+      sendDontHave: boolean
+    }
+
+    export namespace Entry {
+      let _codec: Codec<Entry>
+
+      export const codec = (): Codec<Entry> => {
+        if (_codec == null) {
+          _codec = message<Entry>((obj, w, opts = {}) => {
+            if (opts.lengthDelimited !== false) {
+              w.fork()
+            }
+
+            if (opts.writeDefaults === true || (obj.block != null && obj.block.byteLength > 0)) {
+              w.uint32(10)
+              w.bytes(obj.block ?? new Uint8Array(0))
+            }
+
+            if (opts.writeDefaults === true || (obj.priority != null && obj.priority !== 0)) {
+              w.uint32(16)
+              w.int32(obj.priority ?? 0)
+            }
+
+            if (obj.cancel != null) {
+              w.uint32(24)
+              w.bool(obj.cancel)
+            }
+
+            if (opts.writeDefaults === true || (obj.wantType != null && __WantTypeValues[obj.wantType] !== 0)) {
+              w.uint32(32)
+              Message.Wantlist.WantType.codec().encode(obj.wantType ?? Message.Wantlist.WantType.Block, w)
+            }
+
+            if (opts.writeDefaults === true || (obj.sendDontHave != null && obj.sendDontHave !== false)) {
+              w.uint32(40)
+              w.bool(obj.sendDontHave ?? false)
+            }
+
+            if (opts.lengthDelimited !== false) {
+              w.ldelim()
+            }
+          }, (reader, length) => {
+            const obj: any = {
+              block: new Uint8Array(0),
+              priority: 0,
+              wantType: WantType.Block,
+              sendDontHave: false
+            }
+
+            const end = length == null ? reader.len : reader.pos + length
+
+            while (reader.pos < end) {
+              const tag = reader.uint32()
+
+              switch (tag >>> 3) {
+                case 1:
+                  obj.block = reader.bytes()
+                  break
+                case 2:
+                  obj.priority = reader.int32()
+                  break
+                case 3:
+                  obj.cancel = reader.bool()
+                  break
+                case 4:
+                  obj.wantType = Message.Wantlist.WantType.codec().decode(reader)
+                  break
+                case 5:
+                  obj.sendDontHave = reader.bool()
+                  break
+                default:
+                  reader.skipType(tag & 7)
+                  break
+              }
+            }
+
+            return obj
+          })
+        }
+
+        return _codec
+      }
+
+      export const encode = (obj: Partial<Entry>): Uint8Array => {
+        return encodeMessage(obj, Entry.codec())
+      }
+
+      export const decode = (buf: Uint8Array | Uint8ArrayList): Entry => {
+        return decodeMessage(buf, Entry.codec())
+      }
+    }
+
+    let _codec: Codec<Wantlist>
+
+    export const codec = (): Codec<Wantlist> => {
+      if (_codec == null) {
+        _codec = message<Wantlist>((obj, w, opts = {}) => {
+          if (opts.lengthDelimited !== false) {
+            w.fork()
+          }
+
+          if (obj.entries != null) {
+            for (const value of obj.entries) {
+              w.uint32(10)
+              Message.Wantlist.Entry.codec().encode(value, w)
+            }
+          }
+
+          if (opts.writeDefaults === true || (obj.full != null && obj.full !== false)) {
+            w.uint32(16)
+            w.bool(obj.full ?? false)
+          }
+
+          if (opts.lengthDelimited !== false) {
+            w.ldelim()
+          }
+        }, (reader, length) => {
+          const obj: any = {
+            entries: [],
+            full: false
+          }
+
+          const end = length == null ? reader.len : reader.pos + length
+
+          while (reader.pos < end) {
+            const tag = reader.uint32()
+
+            switch (tag >>> 3) {
+              case 1:
+                obj.entries.push(Message.Wantlist.Entry.codec().decode(reader, reader.uint32()))
+                break
+              case 2:
+                obj.full = reader.bool()
+                break
+              default:
+                reader.skipType(tag & 7)
+                break
+            }
+          }
+
+          return obj
+        })
+      }
+
+      return _codec
+    }
+
+    export const encode = (obj: Partial<Wantlist>): Uint8Array => {
+      return encodeMessage(obj, Wantlist.codec())
+    }
+
+    export const decode = (buf: Uint8Array | Uint8ArrayList): Wantlist => {
+      return decodeMessage(buf, Wantlist.codec())
+    }
+  }
+
+  export interface Block {
+    prefix: Uint8Array
+    data: Uint8Array
+  }
+
+  export namespace Block {
+    let _codec: Codec<Block>
+
+    export const codec = (): Codec<Block> => {
+      if (_codec == null) {
+        _codec = message<Block>((obj, w, opts = {}) => {
+          if (opts.lengthDelimited !== false) {
+            w.fork()
+          }
+
+          if (opts.writeDefaults === true || (obj.prefix != null && obj.prefix.byteLength > 0)) {
+            w.uint32(10)
+            w.bytes(obj.prefix ?? new Uint8Array(0))
+          }
+
+          if (opts.writeDefaults === true || (obj.data != null && obj.data.byteLength > 0)) {
+            w.uint32(18)
+            w.bytes(obj.data ?? new Uint8Array(0))
+          }
+
+          if (opts.lengthDelimited !== false) {
+            w.ldelim()
+          }
+        }, (reader, length) => {
+          const obj: any = {
+            prefix: new Uint8Array(0),
+            data: new Uint8Array(0)
+          }
+
+          const end = length == null ? reader.len : reader.pos + length
+
+          while (reader.pos < end) {
+            const tag = reader.uint32()
+
+            switch (tag >>> 3) {
+              case 1:
+                obj.prefix = reader.bytes()
+                break
+              case 2:
+                obj.data = reader.bytes()
+                break
+              default:
+                reader.skipType(tag & 7)
+                break
+            }
+          }
+
+          return obj
+        })
+      }
+
+      return _codec
+    }
+
+    export const encode = (obj: Partial<Block>): Uint8Array => {
+      return encodeMessage(obj, Block.codec())
+    }
+
+    export const decode = (buf: Uint8Array | Uint8ArrayList): Block => {
+      return decodeMessage(buf, Block.codec())
+    }
+  }
+
+  export enum BlockPresenceType {
+    Have = 'Have',
+    DontHave = 'DontHave'
+  }
+
+  enum __BlockPresenceTypeValues {
+    Have = 0,
+    DontHave = 1
+  }
+
+  export namespace BlockPresenceType {
+    export const codec = (): Codec<BlockPresenceType> => {
+      return enumeration<BlockPresenceType>(__BlockPresenceTypeValues)
+    }
+  }
+
+  export interface BlockPresence {
+    cid: Uint8Array
+    type: Message.BlockPresenceType
+  }
+
+  export namespace BlockPresence {
+    let _codec: Codec<BlockPresence>
+
+    export const codec = (): Codec<BlockPresence> => {
+      if (_codec == null) {
+        _codec = message<BlockPresence>((obj, w, opts = {}) => {
+          if (opts.lengthDelimited !== false) {
+            w.fork()
+          }
+
+          if (opts.writeDefaults === true || (obj.cid != null && obj.cid.byteLength > 0)) {
+            w.uint32(10)
+            w.bytes(obj.cid ?? new Uint8Array(0))
+          }
+
+          if (opts.writeDefaults === true || (obj.type != null && __BlockPresenceTypeValues[obj.type] !== 0)) {
+            w.uint32(16)
+            Message.BlockPresenceType.codec().encode(obj.type ?? Message.BlockPresenceType.Have, w)
+          }
+
+          if (opts.lengthDelimited !== false) {
+            w.ldelim()
+          }
+        }, (reader, length) => {
+          const obj: any = {
+            cid: new Uint8Array(0),
+            type: BlockPresenceType.Have
+          }
+
+          const end = length == null ? reader.len : reader.pos + length
+
+          while (reader.pos < end) {
+            const tag = reader.uint32()
+
+            switch (tag >>> 3) {
+              case 1:
+                obj.cid = reader.bytes()
+                break
+              case 2:
+                obj.type = Message.BlockPresenceType.codec().decode(reader)
+                break
+              default:
+                reader.skipType(tag & 7)
+                break
+            }
+          }
+
+          return obj
+        })
+      }
+
+      return _codec
+    }
+
+    export const encode = (obj: Partial<BlockPresence>): Uint8Array => {
+      return encodeMessage(obj, BlockPresence.codec())
+    }
+
+    export const decode = (buf: Uint8Array | Uint8ArrayList): BlockPresence => {
+      return decodeMessage(buf, BlockPresence.codec())
+    }
+  }
+
+  let _codec: Codec<Message>
+
+  export const codec = (): Codec<Message> => {
+    if (_codec == null) {
+      _codec = message<Message>((obj, w, opts = {}) => {
+        if (opts.lengthDelimited !== false) {
+          w.fork()
+        }
+
+        if (obj.wantlist != null) {
+          w.uint32(10)
+          Message.Wantlist.codec().encode(obj.wantlist, w)
+        }
+
+        if (obj.blocks != null) {
+          for (const value of obj.blocks) {
+            w.uint32(18)
+            w.bytes(value)
+          }
+        }
+
+        if (obj.payload != null) {
+          for (const value of obj.payload) {
+            w.uint32(26)
+            Message.Block.codec().encode(value, w)
+          }
+        }
+
+        if (obj.blockPresences != null) {
+          for (const value of obj.blockPresences) {
+            w.uint32(34)
+            Message.BlockPresence.codec().encode(value, w)
+          }
+        }
+
+        if (opts.writeDefaults === true || (obj.pendingBytes != null && obj.pendingBytes !== 0)) {
+          w.uint32(40)
+          w.int32(obj.pendingBytes ?? 0)
+        }
+
+        if (opts.lengthDelimited !== false) {
+          w.ldelim()
+        }
+      }, (reader, length) => {
+        const obj: any = {
+          blocks: [],
+          payload: [],
+          blockPresences: [],
+          pendingBytes: 0
+        }
+
+        const end = length == null ? reader.len : reader.pos + length
+
+        while (reader.pos < end) {
+          const tag = reader.uint32()
+
+          switch (tag >>> 3) {
+            case 1:
+              obj.wantlist = Message.Wantlist.codec().decode(reader, reader.uint32())
+              break
+            case 2:
+              obj.blocks.push(reader.bytes())
+              break
+            case 3:
+              obj.payload.push(Message.Block.codec().decode(reader, reader.uint32()))
+              break
+            case 4:
+              obj.blockPresences.push(Message.BlockPresence.codec().decode(reader, reader.uint32()))
+              break
+            case 5:
+              obj.pendingBytes = reader.int32()
+              break
+            default:
+              reader.skipType(tag & 7)
+              break
+          }
+        }
+
+        return obj
+      })
+    }
+
+    return _codec
+  }
+
+  export const encode = (obj: Partial<Message>): Uint8Array => {
+    return encodeMessage(obj, Message.codec())
+  }
+
+  export const decode = (buf: Uint8Array | Uint8ArrayList): Message => {
+    return decodeMessage(buf, Message.codec())
+  }
+}

--- a/packages/protons/test/fixtures/circuit.ts
+++ b/packages/protons/test/fixtures/circuit.ts
@@ -166,16 +166,12 @@ export namespace CircuitRelay {
 
         if (obj.srcPeer != null) {
           w.uint32(18)
-          CircuitRelay.Peer.codec().encode(obj.srcPeer, w, {
-            writeDefaults: false
-          })
+          CircuitRelay.Peer.codec().encode(obj.srcPeer, w)
         }
 
         if (obj.dstPeer != null) {
           w.uint32(26)
-          CircuitRelay.Peer.codec().encode(obj.dstPeer, w, {
-            writeDefaults: false
-          })
+          CircuitRelay.Peer.codec().encode(obj.dstPeer, w)
         }
 
         if (obj.code != null) {

--- a/packages/protons/test/fixtures/daemon.ts
+++ b/packages/protons/test/fixtures/daemon.ts
@@ -69,58 +69,42 @@ export namespace Request {
 
         if (obj.connect != null) {
           w.uint32(18)
-          ConnectRequest.codec().encode(obj.connect, w, {
-            writeDefaults: false
-          })
+          ConnectRequest.codec().encode(obj.connect, w)
         }
 
         if (obj.streamOpen != null) {
           w.uint32(26)
-          StreamOpenRequest.codec().encode(obj.streamOpen, w, {
-            writeDefaults: false
-          })
+          StreamOpenRequest.codec().encode(obj.streamOpen, w)
         }
 
         if (obj.streamHandler != null) {
           w.uint32(34)
-          StreamHandlerRequest.codec().encode(obj.streamHandler, w, {
-            writeDefaults: false
-          })
+          StreamHandlerRequest.codec().encode(obj.streamHandler, w)
         }
 
         if (obj.dht != null) {
           w.uint32(42)
-          DHTRequest.codec().encode(obj.dht, w, {
-            writeDefaults: false
-          })
+          DHTRequest.codec().encode(obj.dht, w)
         }
 
         if (obj.connManager != null) {
           w.uint32(50)
-          ConnManagerRequest.codec().encode(obj.connManager, w, {
-            writeDefaults: false
-          })
+          ConnManagerRequest.codec().encode(obj.connManager, w)
         }
 
         if (obj.disconnect != null) {
           w.uint32(58)
-          DisconnectRequest.codec().encode(obj.disconnect, w, {
-            writeDefaults: false
-          })
+          DisconnectRequest.codec().encode(obj.disconnect, w)
         }
 
         if (obj.pubsub != null) {
           w.uint32(66)
-          PSRequest.codec().encode(obj.pubsub, w, {
-            writeDefaults: false
-          })
+          PSRequest.codec().encode(obj.pubsub, w)
         }
 
         if (obj.peerStore != null) {
           w.uint32(74)
-          PeerstoreRequest.codec().encode(obj.peerStore, w, {
-            writeDefaults: false
-          })
+          PeerstoreRequest.codec().encode(obj.peerStore, w)
         }
 
         if (opts.lengthDelimited !== false) {
@@ -230,53 +214,39 @@ export namespace Response {
 
         if (obj.error != null) {
           w.uint32(18)
-          ErrorResponse.codec().encode(obj.error, w, {
-            writeDefaults: false
-          })
+          ErrorResponse.codec().encode(obj.error, w)
         }
 
         if (obj.streamInfo != null) {
           w.uint32(26)
-          StreamInfo.codec().encode(obj.streamInfo, w, {
-            writeDefaults: false
-          })
+          StreamInfo.codec().encode(obj.streamInfo, w)
         }
 
         if (obj.identify != null) {
           w.uint32(34)
-          IdentifyResponse.codec().encode(obj.identify, w, {
-            writeDefaults: false
-          })
+          IdentifyResponse.codec().encode(obj.identify, w)
         }
 
         if (obj.dht != null) {
           w.uint32(42)
-          DHTResponse.codec().encode(obj.dht, w, {
-            writeDefaults: false
-          })
+          DHTResponse.codec().encode(obj.dht, w)
         }
 
         if (obj.peers != null) {
           for (const value of obj.peers) {
             w.uint32(50)
-            PeerInfo.codec().encode(value, w, {
-              writeDefaults: true
-            })
+            PeerInfo.codec().encode(value, w)
           }
         }
 
         if (obj.pubsub != null) {
           w.uint32(58)
-          PSResponse.codec().encode(obj.pubsub, w, {
-            writeDefaults: false
-          })
+          PSResponse.codec().encode(obj.pubsub, w)
         }
 
         if (obj.peerStore != null) {
           w.uint32(66)
-          PeerstoreResponse.codec().encode(obj.peerStore, w, {
-            writeDefaults: false
-          })
+          PeerstoreResponse.codec().encode(obj.peerStore, w)
         }
 
         if (opts.lengthDelimited !== false) {
@@ -957,9 +927,7 @@ export namespace DHTResponse {
 
         if (obj.peer != null) {
           w.uint32(18)
-          PeerInfo.codec().encode(obj.peer, w, {
-            writeDefaults: false
-          })
+          PeerInfo.codec().encode(obj.peer, w)
         }
 
         if (obj.value != null) {
@@ -1630,9 +1598,7 @@ export namespace PeerstoreResponse {
 
         if (obj.peer != null) {
           w.uint32(10)
-          PeerInfo.codec().encode(obj.peer, w, {
-            writeDefaults: false
-          })
+          PeerInfo.codec().encode(obj.peer, w)
         }
 
         if (obj.protos != null) {

--- a/packages/protons/test/fixtures/dht.ts
+++ b/packages/protons/test/fixtures/dht.ts
@@ -183,10 +183,8 @@ export namespace Message {
           }
 
           if (obj.connection != null) {
-            w.uint32(26)
-            Message.ConnectionType.codec().encode(obj.connection, w, {
-              writeDefaults: false
-            })
+            w.uint32(24)
+            Message.ConnectionType.codec().encode(obj.connection, w)
           }
 
           if (opts.lengthDelimited !== false) {
@@ -210,7 +208,7 @@ export namespace Message {
                 obj.addrs.push(reader.bytes())
                 break
               case 3:
-                obj.connection = Message.ConnectionType.codec().decode(reader, reader.uint32())
+                obj.connection = Message.ConnectionType.codec().decode(reader)
                 break
               default:
                 reader.skipType(tag & 7)
@@ -266,18 +264,14 @@ export namespace Message {
         if (obj.closerPeers != null) {
           for (const value of obj.closerPeers) {
             w.uint32(66)
-            Message.Peer.codec().encode(value, w, {
-              writeDefaults: true
-            })
+            Message.Peer.codec().encode(value, w)
           }
         }
 
         if (obj.providerPeers != null) {
           for (const value of obj.providerPeers) {
             w.uint32(74)
-            Message.Peer.codec().encode(value, w, {
-              writeDefaults: true
-            })
+            Message.Peer.codec().encode(value, w)
           }
         }
 

--- a/packages/protons/test/fixtures/maps.ts
+++ b/packages/protons/test/fixtures/maps.ts
@@ -280,7 +280,7 @@ export namespace MapTypes {
 
   export interface MapTypes$messageMapEntry {
     key: string
-    value: SubMessage
+    value?: SubMessage
   }
 
   export namespace MapTypes$messageMapEntry {
@@ -300,9 +300,7 @@ export namespace MapTypes {
 
           if (obj.value != null) {
             w.uint32(18)
-            SubMessage.codec().encode(obj.value, w, {
-              writeDefaults: false
-            })
+            SubMessage.codec().encode(obj.value, w)
           }
 
           if (opts.lengthDelimited !== false) {
@@ -310,8 +308,7 @@ export namespace MapTypes {
           }
         }, (reader, length) => {
           const obj: any = {
-            key: '',
-            value: undefined
+            key: ''
           }
 
           const end = length == null ? reader.len : reader.pos + length
@@ -360,36 +357,28 @@ export namespace MapTypes {
         if (obj.stringMap != null && obj.stringMap.size !== 0) {
           for (const [key, value] of obj.stringMap.entries()) {
             w.uint32(10)
-            MapTypes.MapTypes$stringMapEntry.codec().encode({ key, value }, w, {
-              writeDefaults: true
-            })
+            MapTypes.MapTypes$stringMapEntry.codec().encode({ key, value }, w)
           }
         }
 
         if (obj.intMap != null && obj.intMap.size !== 0) {
           for (const [key, value] of obj.intMap.entries()) {
             w.uint32(18)
-            MapTypes.MapTypes$intMapEntry.codec().encode({ key, value }, w, {
-              writeDefaults: true
-            })
+            MapTypes.MapTypes$intMapEntry.codec().encode({ key, value }, w)
           }
         }
 
         if (obj.boolMap != null && obj.boolMap.size !== 0) {
           for (const [key, value] of obj.boolMap.entries()) {
             w.uint32(26)
-            MapTypes.MapTypes$boolMapEntry.codec().encode({ key, value }, w, {
-              writeDefaults: true
-            })
+            MapTypes.MapTypes$boolMapEntry.codec().encode({ key, value }, w)
           }
         }
 
         if (obj.messageMap != null && obj.messageMap.size !== 0) {
           for (const [key, value] of obj.messageMap.entries()) {
             w.uint32(34)
-            MapTypes.MapTypes$messageMapEntry.codec().encode({ key, value }, w, {
-              writeDefaults: true
-            })
+            MapTypes.MapTypes$messageMapEntry.codec().encode({ key, value }, w)
           }
         }
 

--- a/packages/protons/test/fixtures/optional.ts
+++ b/packages/protons/test/fixtures/optional.ts
@@ -202,9 +202,7 @@ export namespace Optional {
 
         if (obj.subMessage != null) {
           w.uint32(138)
-          OptionalSubMessage.codec().encode(obj.subMessage, w, {
-            writeDefaults: false
-          })
+          OptionalSubMessage.codec().encode(obj.subMessage, w)
         }
 
         if (opts.lengthDelimited !== false) {

--- a/packages/protons/test/fixtures/peer.ts
+++ b/packages/protons/test/fixtures/peer.ts
@@ -29,9 +29,7 @@ export namespace Peer {
         if (obj.addresses != null) {
           for (const value of obj.addresses) {
             w.uint32(10)
-            Address.codec().encode(value, w, {
-              writeDefaults: true
-            })
+            Address.codec().encode(value, w)
           }
         }
 
@@ -45,9 +43,7 @@ export namespace Peer {
         if (obj.metadata != null) {
           for (const value of obj.metadata) {
             w.uint32(26)
-            Metadata.codec().encode(value, w, {
-              writeDefaults: true
-            })
+            Metadata.codec().encode(value, w)
           }
         }
 

--- a/packages/protons/test/fixtures/singular.ts
+++ b/packages/protons/test/fixtures/singular.ts
@@ -205,9 +205,7 @@ export namespace Singular {
 
         if (obj.subMessage != null) {
           w.uint32(138)
-          SingularSubMessage.codec().encode(obj.subMessage, w, {
-            writeDefaults: false
-          })
+          SingularSubMessage.codec().encode(obj.subMessage, w)
         }
 
         if (opts.lengthDelimited !== false) {

--- a/packages/protons/test/fixtures/test.ts
+++ b/packages/protons/test/fixtures/test.ts
@@ -174,9 +174,7 @@ export namespace AllTheTypes {
 
         if (obj.field13 != null) {
           w.uint32(106)
-          SubMessage.codec().encode(obj.field13, w, {
-            writeDefaults: false
-          })
+          SubMessage.codec().encode(obj.field13, w)
         }
 
         if (obj.field14 != null) {


### PR DESCRIPTION
The `defineModule` function wasn't marking nested enums as such so update it to recursively look at nested subtypes when marking types as optional, messages and/or enums.