### PR TITLE
fix: remove writing default values

### DIFF
--- a/packages/protons/test/fixtures/basic.ts
+++ b/packages/protons/test/fixtures/basic.ts
@@ -28,9 +28,9 @@ export namespace Basic {
           w.string(obj.foo)
         }
 
-        if (opts.writeDefaults === true || (obj.num != null && obj.num !== 0)) {
+        if ((obj.num != null && obj.num !== 0)) {
           w.uint32(16)
-          w.int32(obj.num ?? 0)
+          w.int32(obj.num)
         }
 
         if (opts.lengthDelimited !== false) {

--- a/packages/protons/test/fixtures/bitswap.ts
+++ b/packages/protons/test/fixtures/bitswap.ts
@@ -57,14 +57,14 @@ export namespace Message {
               w.fork()
             }
 
-            if (opts.writeDefaults === true || (obj.block != null && obj.block.byteLength > 0)) {
+            if ((obj.block != null && obj.block.byteLength > 0)) {
               w.uint32(10)
-              w.bytes(obj.block ?? new Uint8Array(0))
+              w.bytes(obj.block)
             }
 
-            if (opts.writeDefaults === true || (obj.priority != null && obj.priority !== 0)) {
+            if ((obj.priority != null && obj.priority !== 0)) {
               w.uint32(16)
-              w.int32(obj.priority ?? 0)
+              w.int32(obj.priority)
             }
 
             if (obj.cancel != null) {
@@ -72,14 +72,14 @@ export namespace Message {
               w.bool(obj.cancel)
             }
 
-            if (opts.writeDefaults === true || (obj.wantType != null && __WantTypeValues[obj.wantType] !== 0)) {
+            if (obj.wantType != null && __WantTypeValues[obj.wantType] !== 0) {
               w.uint32(32)
-              Message.Wantlist.WantType.codec().encode(obj.wantType ?? Message.Wantlist.WantType.Block, w)
+              Message.Wantlist.WantType.codec().encode(obj.wantType, w)
             }
 
-            if (opts.writeDefaults === true || (obj.sendDontHave != null && obj.sendDontHave !== false)) {
+            if ((obj.sendDontHave != null && obj.sendDontHave !== false)) {
               w.uint32(40)
-              w.bool(obj.sendDontHave ?? false)
+              w.bool(obj.sendDontHave)
             }
 
             if (opts.lengthDelimited !== false) {
@@ -152,9 +152,9 @@ export namespace Message {
             }
           }
 
-          if (opts.writeDefaults === true || (obj.full != null && obj.full !== false)) {
+          if ((obj.full != null && obj.full !== false)) {
             w.uint32(16)
-            w.bool(obj.full ?? false)
+            w.bool(obj.full)
           }
 
           if (opts.lengthDelimited !== false) {
@@ -215,14 +215,14 @@ export namespace Message {
             w.fork()
           }
 
-          if (opts.writeDefaults === true || (obj.prefix != null && obj.prefix.byteLength > 0)) {
+          if ((obj.prefix != null && obj.prefix.byteLength > 0)) {
             w.uint32(10)
-            w.bytes(obj.prefix ?? new Uint8Array(0))
+            w.bytes(obj.prefix)
           }
 
-          if (opts.writeDefaults === true || (obj.data != null && obj.data.byteLength > 0)) {
+          if ((obj.data != null && obj.data.byteLength > 0)) {
             w.uint32(18)
-            w.bytes(obj.data ?? new Uint8Array(0))
+            w.bytes(obj.data)
           }
 
           if (opts.lengthDelimited !== false) {
@@ -299,14 +299,14 @@ export namespace Message {
             w.fork()
           }
 
-          if (opts.writeDefaults === true || (obj.cid != null && obj.cid.byteLength > 0)) {
+          if ((obj.cid != null && obj.cid.byteLength > 0)) {
             w.uint32(10)
-            w.bytes(obj.cid ?? new Uint8Array(0))
+            w.bytes(obj.cid)
           }
 
-          if (opts.writeDefaults === true || (obj.type != null && __BlockPresenceTypeValues[obj.type] !== 0)) {
+          if (obj.type != null && __BlockPresenceTypeValues[obj.type] !== 0) {
             w.uint32(16)
-            Message.BlockPresenceType.codec().encode(obj.type ?? Message.BlockPresenceType.Have, w)
+            Message.BlockPresenceType.codec().encode(obj.type, w)
           }
 
           if (opts.lengthDelimited !== false) {
@@ -387,9 +387,9 @@ export namespace Message {
           }
         }
 
-        if (opts.writeDefaults === true || (obj.pendingBytes != null && obj.pendingBytes !== 0)) {
+        if ((obj.pendingBytes != null && obj.pendingBytes !== 0)) {
           w.uint32(40)
-          w.int32(obj.pendingBytes ?? 0)
+          w.int32(obj.pendingBytes)
         }
 
         if (opts.lengthDelimited !== false) {

--- a/packages/protons/test/fixtures/circuit.ts
+++ b/packages/protons/test/fixtures/circuit.ts
@@ -95,9 +95,9 @@ export namespace CircuitRelay {
             w.fork()
           }
 
-          if (opts.writeDefaults === true || (obj.id != null && obj.id.byteLength > 0)) {
+          if ((obj.id != null && obj.id.byteLength > 0)) {
             w.uint32(10)
-            w.bytes(obj.id ?? new Uint8Array(0))
+            w.bytes(obj.id)
           }
 
           if (obj.addrs != null) {

--- a/packages/protons/test/fixtures/daemon.ts
+++ b/packages/protons/test/fixtures/daemon.ts
@@ -62,9 +62,9 @@ export namespace Request {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.type != null && __TypeValues[obj.type] !== 0)) {
+        if (obj.type != null && __TypeValues[obj.type] !== 0) {
           w.uint32(8)
-          Request.Type.codec().encode(obj.type ?? Request.Type.IDENTIFY, w)
+          Request.Type.codec().encode(obj.type, w)
         }
 
         if (obj.connect != null) {
@@ -207,9 +207,9 @@ export namespace Response {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.type != null && __TypeValues[obj.type] !== 0)) {
+        if (obj.type != null && __TypeValues[obj.type] !== 0) {
           w.uint32(8)
-          Response.Type.codec().encode(obj.type ?? Response.Type.OK, w)
+          Response.Type.codec().encode(obj.type, w)
         }
 
         if (obj.error != null) {
@@ -325,9 +325,9 @@ export namespace IdentifyResponse {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.id != null && obj.id.byteLength > 0)) {
+        if ((obj.id != null && obj.id.byteLength > 0)) {
           w.uint32(10)
-          w.bytes(obj.id ?? new Uint8Array(0))
+          w.bytes(obj.id)
         }
 
         if (obj.addrs != null) {
@@ -396,9 +396,9 @@ export namespace ConnectRequest {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.peer != null && obj.peer.byteLength > 0)) {
+        if ((obj.peer != null && obj.peer.byteLength > 0)) {
           w.uint32(10)
-          w.bytes(obj.peer ?? new Uint8Array(0))
+          w.bytes(obj.peer)
         }
 
         if (obj.addrs != null) {
@@ -475,9 +475,9 @@ export namespace StreamOpenRequest {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.peer != null && obj.peer.byteLength > 0)) {
+        if ((obj.peer != null && obj.peer.byteLength > 0)) {
           w.uint32(10)
-          w.bytes(obj.peer ?? new Uint8Array(0))
+          w.bytes(obj.peer)
         }
 
         if (obj.proto != null) {
@@ -553,9 +553,9 @@ export namespace StreamHandlerRequest {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.addr != null && obj.addr.byteLength > 0)) {
+        if ((obj.addr != null && obj.addr.byteLength > 0)) {
           w.uint32(10)
-          w.bytes(obj.addr ?? new Uint8Array(0))
+          w.bytes(obj.addr)
         }
 
         if (obj.proto != null) {
@@ -622,9 +622,9 @@ export namespace ErrorResponse {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.msg != null && obj.msg !== '')) {
+        if ((obj.msg != null && obj.msg !== '')) {
           w.uint32(10)
-          w.string(obj.msg ?? '')
+          w.string(obj.msg)
         }
 
         if (opts.lengthDelimited !== false) {
@@ -682,19 +682,19 @@ export namespace StreamInfo {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.peer != null && obj.peer.byteLength > 0)) {
+        if ((obj.peer != null && obj.peer.byteLength > 0)) {
           w.uint32(10)
-          w.bytes(obj.peer ?? new Uint8Array(0))
+          w.bytes(obj.peer)
         }
 
-        if (opts.writeDefaults === true || (obj.addr != null && obj.addr.byteLength > 0)) {
+        if ((obj.addr != null && obj.addr.byteLength > 0)) {
           w.uint32(18)
-          w.bytes(obj.addr ?? new Uint8Array(0))
+          w.bytes(obj.addr)
         }
 
-        if (opts.writeDefaults === true || (obj.proto != null && obj.proto !== '')) {
+        if ((obj.proto != null && obj.proto !== '')) {
           w.uint32(26)
-          w.string(obj.proto ?? '')
+          w.string(obj.proto)
         }
 
         if (opts.lengthDelimited !== false) {
@@ -794,9 +794,9 @@ export namespace DHTRequest {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.type != null && __TypeValues[obj.type] !== 0)) {
+        if (obj.type != null && __TypeValues[obj.type] !== 0) {
           w.uint32(8)
-          DHTRequest.Type.codec().encode(obj.type ?? DHTRequest.Type.FIND_PEER, w)
+          DHTRequest.Type.codec().encode(obj.type, w)
         }
 
         if (obj.peer != null) {
@@ -920,9 +920,9 @@ export namespace DHTResponse {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.type != null && __TypeValues[obj.type] !== 0)) {
+        if (obj.type != null && __TypeValues[obj.type] !== 0) {
           w.uint32(8)
-          DHTResponse.Type.codec().encode(obj.type ?? DHTResponse.Type.BEGIN, w)
+          DHTResponse.Type.codec().encode(obj.type, w)
         }
 
         if (obj.peer != null) {
@@ -995,9 +995,9 @@ export namespace PeerInfo {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.id != null && obj.id.byteLength > 0)) {
+        if ((obj.id != null && obj.id.byteLength > 0)) {
           w.uint32(10)
-          w.bytes(obj.id ?? new Uint8Array(0))
+          w.bytes(obj.id)
         }
 
         if (obj.addrs != null) {
@@ -1085,9 +1085,9 @@ export namespace ConnManagerRequest {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.type != null && __TypeValues[obj.type] !== 0)) {
+        if (obj.type != null && __TypeValues[obj.type] !== 0) {
           w.uint32(8)
-          ConnManagerRequest.Type.codec().encode(obj.type ?? ConnManagerRequest.Type.TAG_PEER, w)
+          ConnManagerRequest.Type.codec().encode(obj.type, w)
         }
 
         if (obj.peer != null) {
@@ -1167,9 +1167,9 @@ export namespace DisconnectRequest {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.peer != null && obj.peer.byteLength > 0)) {
+        if ((obj.peer != null && obj.peer.byteLength > 0)) {
           w.uint32(10)
-          w.bytes(obj.peer ?? new Uint8Array(0))
+          w.bytes(obj.peer)
         }
 
         if (opts.lengthDelimited !== false) {
@@ -1247,9 +1247,9 @@ export namespace PSRequest {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.type != null && __TypeValues[obj.type] !== 0)) {
+        if (obj.type != null && __TypeValues[obj.type] !== 0) {
           w.uint32(8)
-          PSRequest.Type.codec().encode(obj.type ?? PSRequest.Type.GET_TOPICS, w)
+          PSRequest.Type.codec().encode(obj.type, w)
         }
 
         if (obj.topic != null) {
@@ -1518,9 +1518,9 @@ export namespace PeerstoreRequest {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.type != null && __TypeValues[obj.type] !== 0)) {
+        if (obj.type != null && __TypeValues[obj.type] !== 0) {
           w.uint32(8)
-          PeerstoreRequest.Type.codec().encode(obj.type ?? PeerstoreRequest.Type.INVALID, w)
+          PeerstoreRequest.Type.codec().encode(obj.type, w)
         }
 
         if (obj.id != null) {

--- a/packages/protons/test/fixtures/maps.ts
+++ b/packages/protons/test/fixtures/maps.ts
@@ -22,9 +22,9 @@ export namespace SubMessage {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.foo != null && obj.foo !== '')) {
+        if ((obj.foo != null && obj.foo !== '')) {
           w.uint32(10)
-          w.string(obj.foo ?? '')
+          w.string(obj.foo)
         }
 
         if (opts.lengthDelimited !== false) {
@@ -89,14 +89,14 @@ export namespace MapTypes {
             w.fork()
           }
 
-          if (opts.writeDefaults === true || (obj.key != null && obj.key !== '')) {
+          if ((obj.key != null && obj.key !== '')) {
             w.uint32(10)
-            w.string(obj.key ?? '')
+            w.string(obj.key)
           }
 
-          if (opts.writeDefaults === true || (obj.value != null && obj.value !== '')) {
+          if ((obj.value != null && obj.value !== '')) {
             w.uint32(18)
-            w.string(obj.value ?? '')
+            w.string(obj.value)
           }
 
           if (opts.lengthDelimited !== false) {
@@ -157,14 +157,14 @@ export namespace MapTypes {
             w.fork()
           }
 
-          if (opts.writeDefaults === true || (obj.key != null && obj.key !== 0)) {
+          if ((obj.key != null && obj.key !== 0)) {
             w.uint32(8)
-            w.int32(obj.key ?? 0)
+            w.int32(obj.key)
           }
 
-          if (opts.writeDefaults === true || (obj.value != null && obj.value !== 0)) {
+          if ((obj.value != null && obj.value !== 0)) {
             w.uint32(16)
-            w.int32(obj.value ?? 0)
+            w.int32(obj.value)
           }
 
           if (opts.lengthDelimited !== false) {
@@ -225,14 +225,14 @@ export namespace MapTypes {
             w.fork()
           }
 
-          if (opts.writeDefaults === true || (obj.key != null && obj.key !== false)) {
+          if ((obj.key != null && obj.key !== false)) {
             w.uint32(8)
-            w.bool(obj.key ?? false)
+            w.bool(obj.key)
           }
 
-          if (opts.writeDefaults === true || (obj.value != null && obj.value !== false)) {
+          if ((obj.value != null && obj.value !== false)) {
             w.uint32(16)
-            w.bool(obj.value ?? false)
+            w.bool(obj.value)
           }
 
           if (opts.lengthDelimited !== false) {
@@ -293,9 +293,9 @@ export namespace MapTypes {
             w.fork()
           }
 
-          if (opts.writeDefaults === true || (obj.key != null && obj.key !== '')) {
+          if ((obj.key != null && obj.key !== '')) {
             w.uint32(10)
-            w.string(obj.key ?? '')
+            w.string(obj.key)
           }
 
           if (obj.value != null) {

--- a/packages/protons/test/fixtures/noise.ts
+++ b/packages/protons/test/fixtures/noise.ts
@@ -27,19 +27,19 @@ export namespace pb {
             w.fork()
           }
 
-          if (opts.writeDefaults === true || (obj.identityKey != null && obj.identityKey.byteLength > 0)) {
+          if ((obj.identityKey != null && obj.identityKey.byteLength > 0)) {
             w.uint32(10)
-            w.bytes(obj.identityKey ?? new Uint8Array(0))
+            w.bytes(obj.identityKey)
           }
 
-          if (opts.writeDefaults === true || (obj.identitySig != null && obj.identitySig.byteLength > 0)) {
+          if ((obj.identitySig != null && obj.identitySig.byteLength > 0)) {
             w.uint32(18)
-            w.bytes(obj.identitySig ?? new Uint8Array(0))
+            w.bytes(obj.identitySig)
           }
 
-          if (opts.writeDefaults === true || (obj.data != null && obj.data.byteLength > 0)) {
+          if ((obj.data != null && obj.data.byteLength > 0)) {
             w.uint32(26)
-            w.bytes(obj.data ?? new Uint8Array(0))
+            w.bytes(obj.data)
           }
 
           if (opts.lengthDelimited !== false) {

--- a/packages/protons/test/fixtures/peer.ts
+++ b/packages/protons/test/fixtures/peer.ts
@@ -125,9 +125,9 @@ export namespace Address {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.multiaddr != null && obj.multiaddr.byteLength > 0)) {
+        if ((obj.multiaddr != null && obj.multiaddr.byteLength > 0)) {
           w.uint32(10)
-          w.bytes(obj.multiaddr ?? new Uint8Array(0))
+          w.bytes(obj.multiaddr)
         }
 
         if (obj.isCertified != null) {
@@ -192,14 +192,14 @@ export namespace Metadata {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.key != null && obj.key !== '')) {
+        if ((obj.key != null && obj.key !== '')) {
           w.uint32(10)
-          w.string(obj.key ?? '')
+          w.string(obj.key)
         }
 
-        if (opts.writeDefaults === true || (obj.value != null && obj.value.byteLength > 0)) {
+        if ((obj.value != null && obj.value.byteLength > 0)) {
           w.uint32(18)
-          w.bytes(obj.value ?? new Uint8Array(0))
+          w.bytes(obj.value)
         }
 
         if (opts.lengthDelimited !== false) {

--- a/packages/protons/test/fixtures/singular.ts
+++ b/packages/protons/test/fixtures/singular.ts
@@ -40,14 +40,14 @@ export namespace SingularSubMessage {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.foo != null && obj.foo !== '')) {
+        if ((obj.foo != null && obj.foo !== '')) {
           w.uint32(10)
-          w.string(obj.foo ?? '')
+          w.string(obj.foo)
         }
 
-        if (opts.writeDefaults === true || (obj.bar != null && obj.bar !== 0)) {
+        if ((obj.bar != null && obj.bar !== 0)) {
           w.uint32(16)
-          w.int32(obj.bar ?? 0)
+          w.int32(obj.bar)
         }
 
         if (opts.lengthDelimited !== false) {
@@ -123,84 +123,84 @@ export namespace Singular {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.double != null && obj.double !== 0)) {
+        if ((obj.double != null && obj.double !== 0)) {
           w.uint32(9)
-          w.double(obj.double ?? 0)
+          w.double(obj.double)
         }
 
-        if (opts.writeDefaults === true || (obj.float != null && obj.float !== 0)) {
+        if ((obj.float != null && obj.float !== 0)) {
           w.uint32(21)
-          w.float(obj.float ?? 0)
+          w.float(obj.float)
         }
 
-        if (opts.writeDefaults === true || (obj.int32 != null && obj.int32 !== 0)) {
+        if ((obj.int32 != null && obj.int32 !== 0)) {
           w.uint32(24)
-          w.int32(obj.int32 ?? 0)
+          w.int32(obj.int32)
         }
 
-        if (opts.writeDefaults === true || (obj.int64 != null && obj.int64 !== 0n)) {
+        if ((obj.int64 != null && obj.int64 !== 0n)) {
           w.uint32(32)
-          w.int64(obj.int64 ?? 0n)
+          w.int64(obj.int64)
         }
 
-        if (opts.writeDefaults === true || (obj.uint32 != null && obj.uint32 !== 0)) {
+        if ((obj.uint32 != null && obj.uint32 !== 0)) {
           w.uint32(40)
-          w.uint32(obj.uint32 ?? 0)
+          w.uint32(obj.uint32)
         }
 
-        if (opts.writeDefaults === true || (obj.uint64 != null && obj.uint64 !== 0n)) {
+        if ((obj.uint64 != null && obj.uint64 !== 0n)) {
           w.uint32(48)
-          w.uint64(obj.uint64 ?? 0n)
+          w.uint64(obj.uint64)
         }
 
-        if (opts.writeDefaults === true || (obj.sint32 != null && obj.sint32 !== 0)) {
+        if ((obj.sint32 != null && obj.sint32 !== 0)) {
           w.uint32(56)
-          w.sint32(obj.sint32 ?? 0)
+          w.sint32(obj.sint32)
         }
 
-        if (opts.writeDefaults === true || (obj.sint64 != null && obj.sint64 !== 0n)) {
+        if ((obj.sint64 != null && obj.sint64 !== 0n)) {
           w.uint32(64)
-          w.sint64(obj.sint64 ?? 0n)
+          w.sint64(obj.sint64)
         }
 
-        if (opts.writeDefaults === true || (obj.fixed32 != null && obj.fixed32 !== 0)) {
+        if ((obj.fixed32 != null && obj.fixed32 !== 0)) {
           w.uint32(77)
-          w.fixed32(obj.fixed32 ?? 0)
+          w.fixed32(obj.fixed32)
         }
 
-        if (opts.writeDefaults === true || (obj.fixed64 != null && obj.fixed64 !== 0n)) {
+        if ((obj.fixed64 != null && obj.fixed64 !== 0n)) {
           w.uint32(81)
-          w.fixed64(obj.fixed64 ?? 0n)
+          w.fixed64(obj.fixed64)
         }
 
-        if (opts.writeDefaults === true || (obj.sfixed32 != null && obj.sfixed32 !== 0)) {
+        if ((obj.sfixed32 != null && obj.sfixed32 !== 0)) {
           w.uint32(93)
-          w.sfixed32(obj.sfixed32 ?? 0)
+          w.sfixed32(obj.sfixed32)
         }
 
-        if (opts.writeDefaults === true || (obj.sfixed64 != null && obj.sfixed64 !== 0n)) {
+        if ((obj.sfixed64 != null && obj.sfixed64 !== 0n)) {
           w.uint32(97)
-          w.sfixed64(obj.sfixed64 ?? 0n)
+          w.sfixed64(obj.sfixed64)
         }
 
-        if (opts.writeDefaults === true || (obj.bool != null && obj.bool !== false)) {
+        if ((obj.bool != null && obj.bool !== false)) {
           w.uint32(104)
-          w.bool(obj.bool ?? false)
+          w.bool(obj.bool)
         }
 
-        if (opts.writeDefaults === true || (obj.string != null && obj.string !== '')) {
+        if ((obj.string != null && obj.string !== '')) {
           w.uint32(114)
-          w.string(obj.string ?? '')
+          w.string(obj.string)
         }
 
-        if (opts.writeDefaults === true || (obj.bytes != null && obj.bytes.byteLength > 0)) {
+        if ((obj.bytes != null && obj.bytes.byteLength > 0)) {
           w.uint32(122)
-          w.bytes(obj.bytes ?? new Uint8Array(0))
+          w.bytes(obj.bytes)
         }
 
-        if (opts.writeDefaults === true || (obj.enum != null && __SingularEnumValues[obj.enum] !== 0)) {
+        if (obj.enum != null && __SingularEnumValues[obj.enum] !== 0) {
           w.uint32(128)
-          SingularEnum.codec().encode(obj.enum ?? SingularEnum.NO_VALUE, w)
+          SingularEnum.codec().encode(obj.enum, w)
         }
 
         if (obj.subMessage != null) {

--- a/packages/protons/test/fixtures/test.ts
+++ b/packages/protons/test/fixtures/test.ts
@@ -37,9 +37,9 @@ export namespace SubMessage {
           w.fork()
         }
 
-        if (opts.writeDefaults === true || (obj.foo != null && obj.foo !== '')) {
+        if ((obj.foo != null && obj.foo !== '')) {
           w.uint32(10)
-          w.string(obj.foo ?? '')
+          w.string(obj.foo)
         }
 
         if (opts.lengthDelimited !== false) {


### PR DESCRIPTION
With correct singular/optional handling it's not necessary to write default values.

This was previously implemented to write default values for repeated message fields where all fields were singular but those messages are written as zero-length buffers and their fields are set to the default value during decoding so there's no reason to have their values in the buffer.