### PR TITLE
fix: use uint8arrays alloc for new buffers

### DIFF
--- a/packages/protons/package.json
+++ b/packages/protons/package.json
@@ -139,6 +139,7 @@
     "pbjs": "^0.0.14",
     "protobufjs": "^7.0.0",
     "protons-runtime": "^5.0.0",
-    "uint8arraylist": "^2.4.3"
+    "uint8arraylist": "^2.4.3",
+    "uint8arrays": "^4.0.6"
   }
 }

--- a/packages/protons/src/index.ts
+++ b/packages/protons/src/index.ts
@@ -809,7 +809,7 @@ class ModuleDef {
     this.globals = {}
   }
 
-  addImport (module: string, symbol: string, alias?: string) {
+  addImport (module: string, symbol: string, alias?: string): void {
     const defs = this._findDefs(module)
 
     for (const def of defs) {
@@ -832,7 +832,7 @@ class ModuleDef {
     })
   }
 
-  addTypeImport (module: string, symbol: string, alias?: string) {
+  addTypeImport (module: string, symbol: string, alias?: string): void {
     const defs = this._findDefs(module)
 
     for (const def of defs) {

--- a/packages/protons/test/fixtures/basic.ts
+++ b/packages/protons/test/fixtures/basic.ts
@@ -4,8 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, decodeMessage, encodeMessage, message } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface Basic {

--- a/packages/protons/test/fixtures/bitswap.ts
+++ b/packages/protons/test/fixtures/bitswap.ts
@@ -4,8 +4,8 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { enumeration, encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, decodeMessage, encodeMessage, enumeration, message } from 'protons-runtime'
+import { alloc as uint8ArrayAlloc } from 'uint8arrays/alloc'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface Message {
@@ -87,7 +87,7 @@ export namespace Message {
             }
           }, (reader, length) => {
             const obj: any = {
-              block: new Uint8Array(0),
+              block: uint8ArrayAlloc(0),
               priority: 0,
               wantType: WantType.Block,
               sendDontHave: false
@@ -239,8 +239,8 @@ export namespace Message {
           }
         }, (reader, length) => {
           const obj: any = {
-            prefix: new Uint8Array(0),
-            data: new Uint8Array(0)
+            prefix: uint8ArrayAlloc(0),
+            data: uint8ArrayAlloc(0)
           }
 
           const end = length == null ? reader.len : reader.pos + length
@@ -326,7 +326,7 @@ export namespace Message {
           }
         }, (reader, length) => {
           const obj: any = {
-            cid: new Uint8Array(0),
+            cid: uint8ArrayAlloc(0),
             type: BlockPresenceType.Have
           }
 

--- a/packages/protons/test/fixtures/circuit.ts
+++ b/packages/protons/test/fixtures/circuit.ts
@@ -4,8 +4,8 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { enumeration, encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, decodeMessage, encodeMessage, enumeration, message } from 'protons-runtime'
+import { alloc as uint8ArrayAlloc } from 'uint8arrays/alloc'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface CircuitRelay {
@@ -112,7 +112,7 @@ export namespace CircuitRelay {
           }
         }, (reader, length) => {
           const obj: any = {
-            id: new Uint8Array(0),
+            id: uint8ArrayAlloc(0),
             addrs: []
           }
 

--- a/packages/protons/test/fixtures/custom-option-jstype.ts
+++ b/packages/protons/test/fixtures/custom-option-jstype.ts
@@ -4,8 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, decodeMessage, encodeMessage, message } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface CustomOptionNumber {

--- a/packages/protons/test/fixtures/daemon.ts
+++ b/packages/protons/test/fixtures/daemon.ts
@@ -4,8 +4,8 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { enumeration, encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, decodeMessage, encodeMessage, enumeration, message } from 'protons-runtime'
+import { alloc as uint8ArrayAlloc } from 'uint8arrays/alloc'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface Request {
@@ -361,7 +361,7 @@ export namespace IdentifyResponse {
         }
       }, (reader, length) => {
         const obj: any = {
-          id: new Uint8Array(0),
+          id: uint8ArrayAlloc(0),
           addrs: []
         }
 
@@ -440,7 +440,7 @@ export namespace ConnectRequest {
         }
       }, (reader, length) => {
         const obj: any = {
-          peer: new Uint8Array(0),
+          peer: uint8ArrayAlloc(0),
           addrs: []
         }
 
@@ -523,7 +523,7 @@ export namespace StreamOpenRequest {
         }
       }, (reader, length) => {
         const obj: any = {
-          peer: new Uint8Array(0),
+          peer: uint8ArrayAlloc(0),
           proto: []
         }
 
@@ -600,7 +600,7 @@ export namespace StreamHandlerRequest {
         }
       }, (reader, length) => {
         const obj: any = {
-          addr: new Uint8Array(0),
+          addr: uint8ArrayAlloc(0),
           proto: []
         }
 
@@ -737,8 +737,8 @@ export namespace StreamInfo {
         }
       }, (reader, length) => {
         const obj: any = {
-          peer: new Uint8Array(0),
-          addr: new Uint8Array(0),
+          peer: uint8ArrayAlloc(0),
+          addr: uint8ArrayAlloc(0),
           proto: ''
         }
 
@@ -1063,7 +1063,7 @@ export namespace PeerInfo {
         }
       }, (reader, length) => {
         const obj: any = {
-          id: new Uint8Array(0),
+          id: uint8ArrayAlloc(0),
           addrs: []
         }
 
@@ -1236,7 +1236,7 @@ export namespace DisconnectRequest {
         }
       }, (reader, length) => {
         const obj: any = {
-          peer: new Uint8Array(0)
+          peer: uint8ArrayAlloc(0)
         }
 
         const end = length == null ? reader.len : reader.pos + length

--- a/packages/protons/test/fixtures/dht.ts
+++ b/packages/protons/test/fixtures/dht.ts
@@ -4,8 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { encodeMessage, decodeMessage, message, enumeration } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, decodeMessage, encodeMessage, enumeration, message } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface Record {

--- a/packages/protons/test/fixtures/maps.ts
+++ b/packages/protons/test/fixtures/maps.ts
@@ -4,8 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, decodeMessage, encodeMessage, message } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface SubMessage {

--- a/packages/protons/test/fixtures/noise.ts
+++ b/packages/protons/test/fixtures/noise.ts
@@ -4,8 +4,8 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, decodeMessage, encodeMessage, message } from 'protons-runtime'
+import { alloc as uint8ArrayAlloc } from 'uint8arrays/alloc'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface pb {}
@@ -47,9 +47,9 @@ export namespace pb {
           }
         }, (reader, length) => {
           const obj: any = {
-            identityKey: new Uint8Array(0),
-            identitySig: new Uint8Array(0),
-            data: new Uint8Array(0)
+            identityKey: uint8ArrayAlloc(0),
+            identitySig: uint8ArrayAlloc(0),
+            data: uint8ArrayAlloc(0)
           }
 
           const end = length == null ? reader.len : reader.pos + length

--- a/packages/protons/test/fixtures/optional.ts
+++ b/packages/protons/test/fixtures/optional.ts
@@ -4,8 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { enumeration, encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, decodeMessage, encodeMessage, enumeration, message } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export enum OptionalEnum {

--- a/packages/protons/test/fixtures/peer.ts
+++ b/packages/protons/test/fixtures/peer.ts
@@ -4,8 +4,8 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, decodeMessage, encodeMessage, message } from 'protons-runtime'
+import { alloc as uint8ArrayAlloc } from 'uint8arrays/alloc'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface Peer {
@@ -146,7 +146,7 @@ export namespace Address {
         }
       }, (reader, length) => {
         const obj: any = {
-          multiaddr: new Uint8Array(0)
+          multiaddr: uint8ArrayAlloc(0)
         }
 
         const end = length == null ? reader.len : reader.pos + length
@@ -217,7 +217,7 @@ export namespace Metadata {
       }, (reader, length) => {
         const obj: any = {
           key: '',
-          value: new Uint8Array(0)
+          value: uint8ArrayAlloc(0)
         }
 
         const end = length == null ? reader.len : reader.pos + length

--- a/packages/protons/test/fixtures/proto2.ts
+++ b/packages/protons/test/fixtures/proto2.ts
@@ -4,8 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, decodeMessage, encodeMessage, message } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface MessageWithRequired {

--- a/packages/protons/test/fixtures/protons-options.ts
+++ b/packages/protons/test/fixtures/protons-options.ts
@@ -4,8 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { encodeMessage, decodeMessage, message, CodeError } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, CodeError, decodeMessage, encodeMessage, message } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface MessageWithSizeLimitedRepeatedField {

--- a/packages/protons/test/fixtures/singular.ts
+++ b/packages/protons/test/fixtures/singular.ts
@@ -4,8 +4,8 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { enumeration, encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, decodeMessage, encodeMessage, enumeration, message } from 'protons-runtime'
+import { alloc as uint8ArrayAlloc } from 'uint8arrays/alloc'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export enum SingularEnum {
@@ -230,7 +230,7 @@ export namespace Singular {
           sfixed64: 0n,
           bool: false,
           string: '',
-          bytes: new Uint8Array(0),
+          bytes: uint8ArrayAlloc(0),
           enum: SingularEnum.NO_VALUE
         }
 

--- a/packages/protons/test/fixtures/test.ts
+++ b/packages/protons/test/fixtures/test.ts
@@ -4,8 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-import { enumeration, encodeMessage, decodeMessage, message } from 'protons-runtime'
-import type { Codec } from 'protons-runtime'
+import { type Codec, decodeMessage, encodeMessage, enumeration, message } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export enum AnEnum {


### PR DESCRIPTION
Will return `Buffer`s under Node.js which have greater performance than `Uint8Array`s.