### PR TITLE
feat: allow limiting nested repeating fields

### DIFF
--- a/packages/protons-runtime/src/codec.ts
+++ b/packages/protons-runtime/src/codec.ts
@@ -19,11 +19,40 @@ export interface EncodeFunction<T> {
   (value: Partial<T>, writer: Writer, opts?: EncodeOptions): void
 }
 
+// protobuf types that contain multiple values
+type CollectionTypes = any[] | Map<any, any>
+
+// protobuf types that are not collections or messages
+type PrimitiveTypes = boolean | number | string | bigint | Uint8Array
+
+// recursive array/map field length limits
+type CollectionLimits <T> = {
+  [K in keyof T]: T[K] extends CollectionTypes ? number :
+    T[K] extends PrimitiveTypes ? never : Limits<T[K]>
+}
+
+// recursive array member array/map field length limits
+type ArrayElementLimits <T> = {
+  [K in keyof T as `${string & K}$`]: T[K] extends Array<infer ElementType> ?
+      (ElementType extends PrimitiveTypes ? never : Limits<ElementType>) :
+      (T[K] extends PrimitiveTypes ? never : Limits<T[K]>)
+}
+
+// recursive map value array/map field length limits
+type MapValueLimits <T> = {
+  [K in keyof T as `${string & K}$value`]: T[K] extends Map<any, infer MapValueType> ?
+      (MapValueType extends PrimitiveTypes ? never : Limits<MapValueType>) :
+      (T[K] extends PrimitiveTypes ? never : Limits<T[K]>)
+}
+
+// union of collection and array elements
+type Limits<T> = Partial<CollectionLimits<T> & ArrayElementLimits<T> & MapValueLimits<T>>
+
 export interface DecodeOptions<T> {
   /**
    * Runtime-specified limits for lengths of repeated/map fields
    */
-  limits?: Partial<Record<keyof T, number>>
+  limits?: Limits<T>
 }
 
 export interface DecodeFunction<T> {

--- a/packages/protons-runtime/src/decode.ts
+++ b/packages/protons-runtime/src/decode.ts
@@ -2,7 +2,7 @@ import { createReader } from './utils/reader.js'
 import type { Codec, DecodeOptions } from './codec.js'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
-export function decodeMessage <T> (buf: Uint8Array | Uint8ArrayList, codec: Codec<T>, opts?: DecodeOptions<T>): T {
+export function decodeMessage <T> (buf: Uint8Array | Uint8ArrayList, codec: Pick<Codec<T>, 'decode'>, opts?: DecodeOptions<T>): T {
   const reader = createReader(buf)
 
   return codec.decode(reader, undefined, opts)

--- a/packages/protons-runtime/src/encode.ts
+++ b/packages/protons-runtime/src/encode.ts
@@ -1,7 +1,7 @@
 import { createWriter } from './utils/writer.js'
 import type { Codec } from './codec.js'
 
-export function encodeMessage <T> (message: T, codec: Codec<T>): Uint8Array {
+export function encodeMessage <T> (message: Partial<T>, codec: Pick<Codec<T>, 'encode'>): Uint8Array {
   const w = createWriter()
 
   codec.encode(message, w, {

--- a/packages/protons/README.md
+++ b/packages/protons/README.md
@@ -94,6 +94,80 @@ const message = MyMessage.decode(buf, {
 })
 ```
 
+#### Limiting repeating fields of nested messages at runtime
+
+Sub messages with repeating elements can be limited in a similar way:
+
+```protobuf
+message SubMessage {
+  repeated uint32 repeatedField = 1;
+}
+
+message MyMessage {
+  SubMessage message = 1;
+}
+```
+
+```TypeScript
+const message = MyMessage.decode(buf, {
+  limits: {
+    messages: {
+      repeatedField: 5 // the SubMessage can not have more than 5 repeatedField entries
+    }
+  }
+})
+```
+
+#### Limiting repeating fields of repeating messages at runtime
+
+Sub messages defined in repeating elements can be limited by appending `$` to the field name in the runtime limit options:
+
+```protobuf
+message SubMessage {
+ repeated uint32 repeatedField = 1;
+}
+
+message MyMessage {
+  repeated SubMessage messages = 1;
+}
+```
+
+```TypeScript
+const message = MyMessage.decode(buf, {
+  limits: {
+    messages: 5 // max 5x SubMessages
+    messages$: {
+      repeatedField: 5 // no SubMessage can have more than 5 repeatedField entries
+    }
+  }
+})
+```
+
+#### Limiting repeating fields of map entries at runtime
+
+Repeating fields in map entries can be limited by appending `$value` to the field name in the runtime limit options:
+
+```protobuf
+message SubMessage {
+ repeated uint32 repeatedField = 1;
+}
+
+message MyMessage {
+  map<string, SubMessage> messages = 1;
+}
+```
+
+```TypeScript
+const message = MyMessage.decode(buf, {
+  limits: {
+    messages: 5 // max 5x SubMessages in the map
+    messages$value: {
+      repeatedField: 5 // no SubMessage in the map can have more than 5 repeatedField entries
+    }
+  }
+})
+```
+
 ### Overriding 64 bit types
 
 By default 64 bit types are implemented as [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt)s.

--- a/packages/protons/test/fixtures/bitswap.ts
+++ b/packages/protons/test/fixtures/bitswap.ts
@@ -183,7 +183,9 @@ export namespace Message {
                   throw new CodeError('decode error - map field "entries" had too many elements', 'ERR_MAX_LENGTH')
                 }
 
-                obj.entries.push(Message.Wantlist.Entry.codec().decode(reader, reader.uint32()))
+                obj.entries.push(Message.Wantlist.Entry.codec().decode(reader, reader.uint32(), {
+                  limits: opts.limits?.entries$
+                }))
                 break
               }
               case 2: {
@@ -429,7 +431,9 @@ export namespace Message {
 
           switch (tag >>> 3) {
             case 1: {
-              obj.wantlist = Message.Wantlist.codec().decode(reader, reader.uint32())
+              obj.wantlist = Message.Wantlist.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.wantlist
+              })
               break
             }
             case 2: {
@@ -445,7 +449,9 @@ export namespace Message {
                 throw new CodeError('decode error - map field "payload" had too many elements', 'ERR_MAX_LENGTH')
               }
 
-              obj.payload.push(Message.Block.codec().decode(reader, reader.uint32()))
+              obj.payload.push(Message.Block.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.payload$
+              }))
               break
             }
             case 4: {
@@ -453,7 +459,9 @@ export namespace Message {
                 throw new CodeError('decode error - map field "blockPresences" had too many elements', 'ERR_MAX_LENGTH')
               }
 
-              obj.blockPresences.push(Message.BlockPresence.codec().decode(reader, reader.uint32()))
+              obj.blockPresences.push(Message.BlockPresence.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.blockPresences$
+              }))
               break
             }
             case 5: {

--- a/packages/protons/test/fixtures/circuit.ts
+++ b/packages/protons/test/fixtures/circuit.ts
@@ -203,11 +203,15 @@ export namespace CircuitRelay {
               break
             }
             case 2: {
-              obj.srcPeer = CircuitRelay.Peer.codec().decode(reader, reader.uint32())
+              obj.srcPeer = CircuitRelay.Peer.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.srcPeer
+              })
               break
             }
             case 3: {
-              obj.dstPeer = CircuitRelay.Peer.codec().decode(reader, reader.uint32())
+              obj.dstPeer = CircuitRelay.Peer.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.dstPeer
+              })
               break
             }
             case 4: {

--- a/packages/protons/test/fixtures/daemon.ts
+++ b/packages/protons/test/fixtures/daemon.ts
@@ -126,35 +126,51 @@ export namespace Request {
               break
             }
             case 2: {
-              obj.connect = ConnectRequest.codec().decode(reader, reader.uint32())
+              obj.connect = ConnectRequest.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.connect
+              })
               break
             }
             case 3: {
-              obj.streamOpen = StreamOpenRequest.codec().decode(reader, reader.uint32())
+              obj.streamOpen = StreamOpenRequest.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.streamOpen
+              })
               break
             }
             case 4: {
-              obj.streamHandler = StreamHandlerRequest.codec().decode(reader, reader.uint32())
+              obj.streamHandler = StreamHandlerRequest.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.streamHandler
+              })
               break
             }
             case 5: {
-              obj.dht = DHTRequest.codec().decode(reader, reader.uint32())
+              obj.dht = DHTRequest.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.dht
+              })
               break
             }
             case 6: {
-              obj.connManager = ConnManagerRequest.codec().decode(reader, reader.uint32())
+              obj.connManager = ConnManagerRequest.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.connManager
+              })
               break
             }
             case 7: {
-              obj.disconnect = DisconnectRequest.codec().decode(reader, reader.uint32())
+              obj.disconnect = DisconnectRequest.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.disconnect
+              })
               break
             }
             case 8: {
-              obj.pubsub = PSRequest.codec().decode(reader, reader.uint32())
+              obj.pubsub = PSRequest.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.pubsub
+              })
               break
             }
             case 9: {
-              obj.peerStore = PeerstoreRequest.codec().decode(reader, reader.uint32())
+              obj.peerStore = PeerstoreRequest.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.peerStore
+              })
               break
             }
             default: {
@@ -279,19 +295,27 @@ export namespace Response {
               break
             }
             case 2: {
-              obj.error = ErrorResponse.codec().decode(reader, reader.uint32())
+              obj.error = ErrorResponse.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.error
+              })
               break
             }
             case 3: {
-              obj.streamInfo = StreamInfo.codec().decode(reader, reader.uint32())
+              obj.streamInfo = StreamInfo.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.streamInfo
+              })
               break
             }
             case 4: {
-              obj.identify = IdentifyResponse.codec().decode(reader, reader.uint32())
+              obj.identify = IdentifyResponse.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.identify
+              })
               break
             }
             case 5: {
-              obj.dht = DHTResponse.codec().decode(reader, reader.uint32())
+              obj.dht = DHTResponse.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.dht
+              })
               break
             }
             case 6: {
@@ -299,15 +323,21 @@ export namespace Response {
                 throw new CodeError('decode error - map field "peers" had too many elements', 'ERR_MAX_LENGTH')
               }
 
-              obj.peers.push(PeerInfo.codec().decode(reader, reader.uint32()))
+              obj.peers.push(PeerInfo.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.peers$
+              }))
               break
             }
             case 7: {
-              obj.pubsub = PSResponse.codec().decode(reader, reader.uint32())
+              obj.pubsub = PSResponse.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.pubsub
+              })
               break
             }
             case 8: {
-              obj.peerStore = PeerstoreResponse.codec().decode(reader, reader.uint32())
+              obj.peerStore = PeerstoreResponse.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.peerStore
+              })
               break
             }
             default: {
@@ -1021,7 +1051,9 @@ export namespace DHTResponse {
               break
             }
             case 2: {
-              obj.peer = PeerInfo.codec().decode(reader, reader.uint32())
+              obj.peer = PeerInfo.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.peer
+              })
               break
             }
             case 3: {
@@ -1742,7 +1774,9 @@ export namespace PeerstoreResponse {
 
           switch (tag >>> 3) {
             case 1: {
-              obj.peer = PeerInfo.codec().decode(reader, reader.uint32())
+              obj.peer = PeerInfo.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.peer
+              })
               break
             }
             case 2: {

--- a/packages/protons/test/fixtures/dht.ts
+++ b/packages/protons/test/fixtures/dht.ts
@@ -324,7 +324,9 @@ export namespace Message {
                 throw new CodeError('decode error - map field "closerPeers" had too many elements', 'ERR_MAX_LENGTH')
               }
 
-              obj.closerPeers.push(Message.Peer.codec().decode(reader, reader.uint32()))
+              obj.closerPeers.push(Message.Peer.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.closerPeers$
+              }))
               break
             }
             case 9: {
@@ -332,7 +334,9 @@ export namespace Message {
                 throw new CodeError('decode error - map field "providerPeers" had too many elements', 'ERR_MAX_LENGTH')
               }
 
-              obj.providerPeers.push(Message.Peer.codec().decode(reader, reader.uint32()))
+              obj.providerPeers.push(Message.Peer.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.providerPeers$
+              }))
               break
             }
             default: {

--- a/packages/protons/test/fixtures/maps.proto
+++ b/packages/protons/test/fixtures/maps.proto
@@ -1,7 +1,14 @@
 syntax = "proto3";
 
+enum EnumValue {
+  NO_VALUE = 0;
+  VALUE_1 = 1;
+  VALUE_2 = 2;
+}
+
 message SubMessage {
   string foo = 1;
+  repeated uint32 bar = 2;
 }
 
 message MapTypes {
@@ -9,4 +16,5 @@ message MapTypes {
   map<int32, int32> intMap = 2;
   map<bool, bool> boolMap = 3;
   map<string, SubMessage> messageMap = 4;
+  map<string, EnumValue> enumMap = 5;
 }

--- a/packages/protons/test/fixtures/optional.ts
+++ b/packages/protons/test/fixtures/optional.ts
@@ -284,7 +284,9 @@ export namespace Optional {
               break
             }
             case 17: {
-              obj.subMessage = OptionalSubMessage.codec().decode(reader, reader.uint32())
+              obj.subMessage = OptionalSubMessage.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.subMessage
+              })
               break
             }
             default: {

--- a/packages/protons/test/fixtures/peer.ts
+++ b/packages/protons/test/fixtures/peer.ts
@@ -78,7 +78,9 @@ export namespace Peer {
                 throw new CodeError('decode error - map field "addresses" had too many elements', 'ERR_MAX_LENGTH')
               }
 
-              obj.addresses.push(Address.codec().decode(reader, reader.uint32()))
+              obj.addresses.push(Address.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.addresses$
+              }))
               break
             }
             case 2: {
@@ -94,7 +96,9 @@ export namespace Peer {
                 throw new CodeError('decode error - map field "metadata" had too many elements', 'ERR_MAX_LENGTH')
               }
 
-              obj.metadata.push(Metadata.codec().decode(reader, reader.uint32()))
+              obj.metadata.push(Metadata.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.metadata$
+              }))
               break
             }
             case 4: {

--- a/packages/protons/test/fixtures/protons-options.proto
+++ b/packages/protons/test/fixtures/protons-options.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-import "protons.proto";
-
 message MessageWithSizeLimitedRepeatedField {
   repeated string repeatedField = 1 [(protons.options).limit = 1];
 }

--- a/packages/protons/test/fixtures/repeated.proto
+++ b/packages/protons/test/fixtures/repeated.proto
@@ -1,11 +1,21 @@
 syntax = "proto3";
 
+message SubSubMessage {
+  repeated string foo = 1;
+  optional uint32 nonRepeating = 2;
+}
+
 message SubMessage {
-  string foo = 1;
+  repeated string foo = 1;
+  optional uint32 nonRepeating = 2;
+  optional SubSubMessage message = 3;
+  repeated SubSubMessage messages = 4;
 }
 
 message RepeatedTypes {
   repeated uint32 number = 1;
   repeated uint32 limitedNumber = 2 [(protons.options).limit = 1];
-  repeated SubMessage message = 3;
+  repeated SubMessage messages = 3;
+  optional SubMessage message = 4;
+  optional uint32 nonRepeating = 5;
 }

--- a/packages/protons/test/fixtures/singular.ts
+++ b/packages/protons/test/fixtures/singular.ts
@@ -305,7 +305,9 @@ export namespace Singular {
               break
             }
             case 17: {
-              obj.subMessage = SingularSubMessage.codec().decode(reader, reader.uint32())
+              obj.subMessage = SingularSubMessage.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.subMessage
+              })
               break
             }
             default: {

--- a/packages/protons/test/fixtures/test.ts
+++ b/packages/protons/test/fixtures/test.ts
@@ -268,7 +268,9 @@ export namespace AllTheTypes {
               break
             }
             case 13: {
-              obj.field13 = SubMessage.codec().decode(reader, reader.uint32())
+              obj.field13 = SubMessage.codec().decode(reader, reader.uint32(), {
+                limits: opts.limits?.field13
+              })
               break
             }
             case 14: {

--- a/packages/protons/test/repeated.spec.ts
+++ b/packages/protons/test/repeated.spec.ts
@@ -8,7 +8,7 @@ describe('repeated', () => {
     const obj: RepeatedTypes = {
       number: [],
       limitedNumber: [],
-      message: []
+      messages: []
     }
 
     const buf = RepeatedTypes.encode(obj)
@@ -19,7 +19,7 @@ describe('repeated', () => {
     const obj: RepeatedTypes = {
       number: [],
       limitedNumber: [1, 2],
-      message: []
+      messages: []
     }
 
     const buf = RepeatedTypes.encode(obj)
@@ -30,13 +30,110 @@ describe('repeated', () => {
     const obj: RepeatedTypes = {
       number: [1, 2],
       limitedNumber: [],
-      message: []
+      messages: []
     }
 
     const buf = RepeatedTypes.encode(obj)
     expect(() => RepeatedTypes.decode(buf, {
       limits: {
         number: 1
+      }
+    })).to.throw(/too many elements/)
+  })
+
+  it('should limit repeating repeating fields using runtime options', () => {
+    const obj: RepeatedTypes = {
+      number: [],
+      limitedNumber: [],
+      messages: [{
+        foo: ['one', 'two'],
+        nonRepeating: 0,
+        messages: []
+      }],
+      nonRepeating: 5
+    }
+
+    const buf = RepeatedTypes.encode(obj)
+    expect(() => RepeatedTypes.decode(buf, {
+      limits: {
+        messages$: {
+          foo: 1
+        }
+      }
+    })).to.throw(/too many elements/)
+  })
+
+  it('should limit repeating nested repeating fields using runtime options', () => {
+    const obj: RepeatedTypes = {
+      number: [],
+      limitedNumber: [],
+      messages: [{
+        foo: [],
+        nonRepeating: 0,
+        messages: [{
+          foo: ['one', 'two'],
+          nonRepeating: 0
+        }]
+      }],
+      nonRepeating: 5
+    }
+
+    const buf = RepeatedTypes.encode(obj)
+    expect(() => RepeatedTypes.decode(buf, {
+      limits: {
+        messages$: {
+          messages$: {
+            foo: 1
+          }
+        }
+      }
+    })).to.throw(/too many elements/)
+  })
+
+  it('should limit nested repeating fields using runtime options', () => {
+    const obj: RepeatedTypes = {
+      number: [],
+      limitedNumber: [],
+      messages: [],
+      nonRepeating: 5,
+      message: {
+        foo: ['one', 'two'],
+        messages: []
+      }
+    }
+
+    const buf = RepeatedTypes.encode(obj)
+    expect(() => RepeatedTypes.decode(buf, {
+      limits: {
+        message: {
+          foo: 1
+        }
+      }
+    })).to.throw(/too many elements/)
+  })
+
+  it('should limit nested repeating nested repeating fields using runtime options', () => {
+    const obj: RepeatedTypes = {
+      number: [],
+      limitedNumber: [],
+      messages: [],
+      nonRepeating: 5,
+      message: {
+        foo: [],
+        messages: [{
+          foo: ['one', 'two']
+        }]
+      }
+    }
+
+    const buf = RepeatedTypes.encode(obj)
+    expect(() => RepeatedTypes.decode(buf, {
+      limits: {
+        message: {
+          messages$: {
+            foo: 1
+          }
+        }
       }
     })).to.throw(/too many elements/)
   })

--- a/packages/protons/tsconfig.json
+++ b/packages/protons/tsconfig.json
@@ -10,10 +10,6 @@
     "src",
     "test"
   ],
-  "exclude": [
-    "test/fixtures/*.pbjs.ts",
-    "test/fixtures/*.protobuf.js"
-  ],
   "references": [
     {
       "path": "../protons-runtime"


### PR DESCRIPTION
Passes the limit config through to child message decoders to allow limiting the length of nested repeating fields at runtime.

E.g.

```protobuf
message SubMessage {
  repeated uint32 repeatedField = 1;
}

message MyMessage {
  repeated SubMessage messages = 1;
}
```

```TypeScript
const message = MyMessage.decode(buf, {
  limit: {
    messages: 5 // limit messages length
    messages$: {
      repeatedField: 5 // limit `repeatedField` field of all messages in the messages field
    }
  }
})
```
`