### PR TITLE
feat: allow overriding bytes as string

### DIFF
--- a/packages/protons/src/index.ts
+++ b/packages/protons/src/index.ts
@@ -259,10 +259,10 @@ const encoderGenerators: Record<string, (val: string, jsTypeOverride?: 'number' 
   bool: (val) => `w.bool(${val})`,
   bytes: (val, jsTypeOverride) => {
     if (jsTypeOverride === 'string') {
-      return `w.int64String(${val})`
+      return `w.bytes(new TextEncoder().encode(${val}))`
     }
 
-    return `w.bytes(new TextEncoder().encode(${val}))`
+    return `w.bytes(${val})`
   },
   double: (val) => `w.double(${val})`,
   fixed32: (val) => `w.fixed32(${val})`,

--- a/packages/protons/test/custom-options.spec.ts
+++ b/packages/protons/test/custom-options.spec.ts
@@ -26,7 +26,9 @@ describe('custom options', () => {
       si64: '5',
       f64: '5',
       sf64: '5',
-      bytes: ''
+      bytes: '',
+      byteList: [],
+      regularBytes: new Uint8Array(0)
     }
 
     expect(CustomOptionString.decode(CustomOptionString.encode(obj)))

--- a/packages/protons/test/custom-options.spec.ts
+++ b/packages/protons/test/custom-options.spec.ts
@@ -25,7 +25,8 @@ describe('custom options', () => {
       ui64: '5',
       si64: '5',
       f64: '5',
-      sf64: '5'
+      sf64: '5',
+      bytes: ''
     }
 
     expect(CustomOptionString.decode(CustomOptionString.encode(obj)))

--- a/packages/protons/test/fixtures/custom-option-jstype.proto
+++ b/packages/protons/test/fixtures/custom-option-jstype.proto
@@ -16,4 +16,5 @@ message CustomOptionString {
   sint64 si64 = 4 [jstype = JS_STRING];
   fixed64 f64 = 5 [jstype = JS_STRING];
   sfixed64 sf64 = 6 [jstype = JS_STRING];
+  bytes bytes = 7 [jstype = JS_STRING];
 }

--- a/packages/protons/test/fixtures/custom-option-jstype.proto
+++ b/packages/protons/test/fixtures/custom-option-jstype.proto
@@ -17,4 +17,6 @@ message CustomOptionString {
   fixed64 f64 = 5 [jstype = JS_STRING];
   sfixed64 sf64 = 6 [jstype = JS_STRING];
   bytes bytes = 7 [jstype = JS_STRING];
+  repeated bytes byteList = 8 [jstype = JS_STRING];
+  bytes regularBytes = 9;
 }

--- a/packages/protons/test/fixtures/custom-option-jstype.ts
+++ b/packages/protons/test/fixtures/custom-option-jstype.ts
@@ -129,6 +129,7 @@ export interface CustomOptionString {
   si64: string
   f64: string
   sf64: string
+  bytes: string
 }
 
 export namespace CustomOptionString {
@@ -171,6 +172,11 @@ export namespace CustomOptionString {
           w.sfixed64String(obj.sf64)
         }
 
+        if ((obj.bytes != null && obj.bytes !== '')) {
+          w.uint32(58)
+          w.int64String(obj.bytes)
+        }
+
         if (opts.lengthDelimited !== false) {
           w.ldelim()
         }
@@ -181,7 +187,8 @@ export namespace CustomOptionString {
           ui64: '',
           si64: '',
           f64: '',
-          sf64: ''
+          sf64: '',
+          bytes: ''
         }
 
         const end = length == null ? reader.len : reader.pos + length
@@ -212,6 +219,10 @@ export namespace CustomOptionString {
             }
             case 6: {
               obj.sf64 = reader.sfixed64String()
+              break
+            }
+            case 7: {
+              obj.bytes = new TextDecoder().decode(reader.bytes())
               break
             }
             default: {


### PR DESCRIPTION
Allows interperting a `bytes` field as a `string` type in JavaScript:

```protobuf
message MyMessage {
  bytes field = 1 [jstype = JS_STRING];
}
```