### PR TITLE
fix!: uint8arrays are generic

### DIFF
--- a/packages/protons-benchmark/package.json
+++ b/packages/protons-benchmark/package.json
@@ -27,7 +27,7 @@
     "protobufjs": "^7.5.4",
     "protons": "^8.0.0",
     "protons-runtime": "^6.0.0",
-    "uint8arraylist": "^2.4.8"
+    "uint8arraylist": "^3.0.0"
   },
   "private": true
 }

--- a/packages/protons-benchmark/src/implementations/protons/bench.ts
+++ b/packages/protons-benchmark/src/implementations/protons/bench.ts
@@ -78,7 +78,7 @@ export namespace Foo {
     value: number
   }
 
-  export function encode (obj: Partial<Foo>): Uint8Array {
+  export function encode (obj: Partial<Foo>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, Foo.codec())
   }
 

--- a/packages/protons-benchmark/src/implementations/protons/bench.ts
+++ b/packages/protons-benchmark/src/implementations/protons/bench.ts
@@ -1,5 +1,3 @@
-/* eslint-disable require-yield */
-
 import { decodeMessage, encodeMessage, enumeration, MaxLengthError, message, streamMessage } from 'protons-runtime'
 import type { Codec, DecodeOptions } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'

--- a/packages/protons-runtime/package.json
+++ b/packages/protons-runtime/package.json
@@ -131,9 +131,9 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "uint8-varint": "^2.0.4",
-    "uint8arraylist": "^2.4.8",
-    "uint8arrays": "^5.1.0"
+    "uint8-varint": "^3.0.0",
+    "uint8arraylist": "^3.0.0",
+    "uint8arrays": "^6.0.0"
   },
   "devDependencies": {
     "aegir": "^48.0.1"

--- a/packages/protons-runtime/src/encode.ts
+++ b/packages/protons-runtime/src/encode.ts
@@ -1,7 +1,7 @@
 import { createWriter } from './utils/writer.ts'
 import type { Codec } from './codec.ts'
 
-export function encodeMessage <T> (message: Partial<T>, codec: Pick<Codec<T>, 'encode'>): Uint8Array {
+export function encodeMessage <T> (message: Partial<T>, codec: Pick<Codec<T>, 'encode'>): Uint8Array<ArrayBuffer> {
   const w = createWriter()
 
   codec.encode(message, w, {

--- a/packages/protons-runtime/src/index.ts
+++ b/packages/protons-runtime/src/index.ts
@@ -188,7 +188,7 @@ export interface Writer {
   /**
    * Finishes the write operation
    */
-  finish(): Uint8Array
+  finish(): Uint8Array<ArrayBuffer>
 }
 
 export interface Reader {
@@ -250,7 +250,7 @@ export interface Reader {
   /**
    * Reads a sequence of bytes preceded by its length as a varint
    */
-  bytes(): Uint8Array
+  bytes(): Uint8Array<ArrayBuffer>
 
   /**
    * Reads a string preceded by its byte length as a varint

--- a/packages/protons-runtime/src/utils/pool.ts
+++ b/packages/protons-runtime/src/utils/pool.ts
@@ -3,10 +3,10 @@ import { allocUnsafe } from 'uint8arrays/alloc'
 /**
  * A general purpose buffer pool
  */
-export default function pool (size?: number): (size: number) => Uint8Array {
+export default function pool (size?: number): (size: number) => Uint8Array<ArrayBuffer> {
   const SIZE = size ?? 8192
   const MAX = SIZE >>> 1
-  let slab: Uint8Array
+  let slab: Uint8Array<ArrayBuffer>
   let offset = SIZE
   return function poolAlloc (size: number) {
     if (size < 1 || size > MAX) {

--- a/packages/protons-runtime/src/utils/reader.ts
+++ b/packages/protons-runtime/src/utils/reader.ts
@@ -4,6 +4,7 @@ import { LongBits } from './longbits.ts'
 import * as utf8 from './utf8.ts'
 import type { Reader } from '../index.ts'
 import type { Uint8ArrayList } from 'uint8arraylist'
+import { withArrayBuffer } from 'uint8arrays/with-array-buffer'
 
 /* istanbul ignore next */
 function indexOutOfRange (reader: Reader, writeLength?: number): RangeError {
@@ -21,7 +22,7 @@ function readFixed32End (buf: Uint8Array, end: number): number { // note that th
  * Constructs a new reader instance using the specified buffer.
  */
 export class Uint8ArrayReader implements Reader {
-  public buf: Uint8Array
+  public buf: Uint8Array<ArrayBuffer>
   public pos: number
   public len: number
 
@@ -31,7 +32,7 @@ export class Uint8ArrayReader implements Reader {
     /**
      * Read buffer
      */
-    this.buf = buffer
+    this.buf = withArrayBuffer(buffer)
 
     /**
      * Read buffer position
@@ -138,7 +139,7 @@ export class Uint8ArrayReader implements Reader {
   /**
    * Reads a sequence of bytes preceded by its length as a varint
    */
-  bytes (): Uint8Array {
+  bytes (): Uint8Array<ArrayBuffer> {
     const length = this.uint32()
     const start = this.pos
     const end = this.pos + length

--- a/packages/protons-runtime/src/utils/reader.ts
+++ b/packages/protons-runtime/src/utils/reader.ts
@@ -1,10 +1,10 @@
 import { decodeUint8Array, encodingLength } from 'uint8-varint'
+import { withArrayBuffer } from 'uint8arrays/with-array-buffer'
 import { readFloatLE, readDoubleLE } from './float.ts'
 import { LongBits } from './longbits.ts'
 import * as utf8 from './utf8.ts'
 import type { Reader } from '../index.ts'
 import type { Uint8ArrayList } from 'uint8arraylist'
-import { withArrayBuffer } from 'uint8arrays/with-array-buffer'
 
 /* istanbul ignore next */
 function indexOutOfRange (reader: Reader, writeLength?: number): RangeError {

--- a/packages/protons-runtime/src/utils/writer.ts
+++ b/packages/protons-runtime/src/utils/writer.ts
@@ -85,7 +85,7 @@ const bufferPool = pool()
 /**
  * Allocates a buffer of the specified size
  */
-function alloc (size: number): Uint8Array {
+function alloc (size: number): Uint8Array<ArrayBuffer> {
   if (globalThis.Buffer != null) {
     return allocUnsafe(size)
   }
@@ -393,7 +393,7 @@ class Uint8ArrayWriter implements Writer {
   /**
    * Finishes the write operation
    */
-  finish (): Uint8Array {
+  finish (): Uint8Array<ArrayBuffer> {
     let head = this.head.next // skip noop
     const buf = alloc(this.len)
     let pos = 0

--- a/packages/protons/package.json
+++ b/packages/protons/package.json
@@ -146,7 +146,7 @@
     "long": "^5.3.2",
     "pbjs": "^0.0.14",
     "protobufjs": "^7.5.4",
-    "uint8arraylist": "^2.4.8",
-    "uint8arrays": "^5.1.0"
+    "uint8arraylist": "^3.0.0",
+    "uint8arrays": "^6.0.0"
   }
 }

--- a/packages/protons/src/types/message.ts
+++ b/packages/protons/src/types/message.ts
@@ -334,7 +334,7 @@ ${enforceOneOfDecoding === '' ? '' : `${enforceOneOfDecoding}\n`}
     return _codec
   }${this.formatStreamEvents(streamEvents)}
 
-  export function encode (obj: Partial<${this.pbType}>): Uint8Array {
+  export function encode (obj: Partial<${this.pbType}>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, ${this.pbType}.codec())
   }
 

--- a/packages/protons/test/fixtures/basic.ts
+++ b/packages/protons/test/fixtures/basic.ts
@@ -102,7 +102,7 @@ export namespace Basic {
     value: number
   }
 
-  export function encode (obj: Partial<Basic>): Uint8Array {
+  export function encode (obj: Partial<Basic>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, Basic.codec())
   }
 
@@ -166,7 +166,7 @@ export namespace Empty {
     return _codec
   }
 
-  export function encode (obj: Partial<Empty>): Uint8Array {
+  export function encode (obj: Partial<Empty>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, Empty.codec())
   }
 

--- a/packages/protons/test/fixtures/bitswap.ts
+++ b/packages/protons/test/fixtures/bitswap.ts
@@ -201,7 +201,7 @@ export namespace Message {
         value: boolean
       }
 
-      export function encode (obj: Partial<Entry>): Uint8Array {
+      export function encode (obj: Partial<Entry>): Uint8Array<ArrayBuffer> {
         return encodeMessage(obj, Entry.codec())
       }
 
@@ -355,7 +355,7 @@ export namespace Message {
       value: boolean
     }
 
-    export function encode (obj: Partial<Wantlist>): Uint8Array {
+    export function encode (obj: Partial<Wantlist>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, Wantlist.codec())
     }
 
@@ -467,7 +467,7 @@ export namespace Message {
       value: Uint8Array
     }
 
-    export function encode (obj: Partial<Block>): Uint8Array {
+    export function encode (obj: Partial<Block>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, Block.codec())
     }
 
@@ -595,7 +595,7 @@ export namespace Message {
       value: Message.BlockPresenceType
     }
 
-    export function encode (obj: Partial<BlockPresence>): Uint8Array {
+    export function encode (obj: Partial<BlockPresence>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, BlockPresence.codec())
     }
 
@@ -871,7 +871,7 @@ export namespace Message {
     value: number
   }
 
-  export function encode (obj: Partial<Message>): Uint8Array {
+  export function encode (obj: Partial<Message>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, Message.codec())
   }
 

--- a/packages/protons/test/fixtures/circuit.ts
+++ b/packages/protons/test/fixtures/circuit.ts
@@ -193,7 +193,7 @@ export namespace CircuitRelay {
       value: Uint8Array
     }
 
-    export function encode (obj: Partial<Peer>): Uint8Array {
+    export function encode (obj: Partial<Peer>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, Peer.codec())
     }
 
@@ -354,7 +354,7 @@ export namespace CircuitRelay {
     value: CircuitRelay.Status
   }
 
-  export function encode (obj: Partial<CircuitRelay>): Uint8Array {
+  export function encode (obj: Partial<CircuitRelay>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, CircuitRelay.codec())
   }
 

--- a/packages/protons/test/fixtures/custom-option-jstype.ts
+++ b/packages/protons/test/fixtures/custom-option-jstype.ts
@@ -113,7 +113,7 @@ export namespace CustomOptionNumber {
       value: number
     }
 
-    export function encode (obj: Partial<CustomOptionNumber$i64MapEntry>): Uint8Array {
+    export function encode (obj: Partial<CustomOptionNumber$i64MapEntry>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, CustomOptionNumber$i64MapEntry.codec())
     }
 
@@ -391,7 +391,7 @@ export namespace CustomOptionNumber {
     value: number
   }
 
-  export function encode (obj: Partial<CustomOptionNumber>): Uint8Array {
+  export function encode (obj: Partial<CustomOptionNumber>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, CustomOptionNumber.codec())
   }
 
@@ -515,7 +515,7 @@ export namespace CustomOptionString {
       value: string
     }
 
-    export function encode (obj: Partial<CustomOptionString$i64MapEntry>): Uint8Array {
+    export function encode (obj: Partial<CustomOptionString$i64MapEntry>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, CustomOptionString$i64MapEntry.codec())
     }
 
@@ -793,7 +793,7 @@ export namespace CustomOptionString {
     value: string
   }
 
-  export function encode (obj: Partial<CustomOptionString>): Uint8Array {
+  export function encode (obj: Partial<CustomOptionString>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, CustomOptionString.codec())
   }
 

--- a/packages/protons/test/fixtures/daemon.ts
+++ b/packages/protons/test/fixtures/daemon.ts
@@ -397,7 +397,7 @@ export namespace Request {
     value: string
   }
 
-  export function encode (obj: Partial<Request>): Uint8Array {
+  export function encode (obj: Partial<Request>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, Request.codec())
   }
 
@@ -750,7 +750,7 @@ export namespace Response {
     value: string
   }
 
-  export function encode (obj: Partial<Response>): Uint8Array {
+  export function encode (obj: Partial<Response>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, Response.codec())
   }
 
@@ -881,7 +881,7 @@ export namespace IdentifyResponse {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<IdentifyResponse>): Uint8Array {
+  export function encode (obj: Partial<IdentifyResponse>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, IdentifyResponse.codec())
   }
 
@@ -1034,7 +1034,7 @@ export namespace ConnectRequest {
     value: bigint
   }
 
-  export function encode (obj: Partial<ConnectRequest>): Uint8Array {
+  export function encode (obj: Partial<ConnectRequest>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, ConnectRequest.codec())
   }
 
@@ -1187,7 +1187,7 @@ export namespace StreamOpenRequest {
     value: bigint
   }
 
-  export function encode (obj: Partial<StreamOpenRequest>): Uint8Array {
+  export function encode (obj: Partial<StreamOpenRequest>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, StreamOpenRequest.codec())
   }
 
@@ -1318,7 +1318,7 @@ export namespace StreamHandlerRequest {
     value: string
   }
 
-  export function encode (obj: Partial<StreamHandlerRequest>): Uint8Array {
+  export function encode (obj: Partial<StreamHandlerRequest>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, StreamHandlerRequest.codec())
   }
 
@@ -1407,7 +1407,7 @@ export namespace ErrorResponse {
     value: string
   }
 
-  export function encode (obj: Partial<ErrorResponse>): Uint8Array {
+  export function encode (obj: Partial<ErrorResponse>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, ErrorResponse.codec())
   }
 
@@ -1542,7 +1542,7 @@ export namespace StreamInfo {
     value: string
   }
 
-  export function encode (obj: Partial<StreamInfo>): Uint8Array {
+  export function encode (obj: Partial<StreamInfo>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, StreamInfo.codec())
   }
 
@@ -1793,7 +1793,7 @@ export namespace DHTRequest {
     value: bigint
   }
 
-  export function encode (obj: Partial<DHTRequest>): Uint8Array {
+  export function encode (obj: Partial<DHTRequest>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, DHTRequest.codec())
   }
 
@@ -1952,7 +1952,7 @@ export namespace DHTResponse {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<DHTResponse>): Uint8Array {
+  export function encode (obj: Partial<DHTResponse>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, DHTResponse.codec())
   }
 
@@ -2083,7 +2083,7 @@ export namespace PeerInfo {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<PeerInfo>): Uint8Array {
+  export function encode (obj: Partial<PeerInfo>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, PeerInfo.codec())
   }
 
@@ -2256,7 +2256,7 @@ export namespace ConnManagerRequest {
     value: bigint
   }
 
-  export function encode (obj: Partial<ConnManagerRequest>): Uint8Array {
+  export function encode (obj: Partial<ConnManagerRequest>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, ConnManagerRequest.codec())
   }
 
@@ -2345,7 +2345,7 @@ export namespace DisconnectRequest {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<DisconnectRequest>): Uint8Array {
+  export function encode (obj: Partial<DisconnectRequest>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, DisconnectRequest.codec())
   }
 
@@ -2498,7 +2498,7 @@ export namespace PSRequest {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<PSRequest>): Uint8Array {
+  export function encode (obj: Partial<PSRequest>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, PSRequest.codec())
   }
 
@@ -2716,7 +2716,7 @@ export namespace PSMessage {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<PSMessage>): Uint8Array {
+  export function encode (obj: Partial<PSMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, PSMessage.codec())
   }
 
@@ -2863,7 +2863,7 @@ export namespace PSResponse {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<PSResponse>): Uint8Array {
+  export function encode (obj: Partial<PSResponse>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, PSResponse.codec())
   }
 
@@ -3034,7 +3034,7 @@ export namespace PeerstoreRequest {
     value: string
   }
 
-  export function encode (obj: Partial<PeerstoreRequest>): Uint8Array {
+  export function encode (obj: Partial<PeerstoreRequest>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, PeerstoreRequest.codec())
   }
 
@@ -3172,7 +3172,7 @@ export namespace PeerstoreResponse {
     value: string
   }
 
-  export function encode (obj: Partial<PeerstoreResponse>): Uint8Array {
+  export function encode (obj: Partial<PeerstoreResponse>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, PeerstoreResponse.codec())
   }
 

--- a/packages/protons/test/fixtures/dht.ts
+++ b/packages/protons/test/fixtures/dht.ts
@@ -164,7 +164,7 @@ export namespace Record {
     value: string
   }
 
-  export function encode (obj: Partial<Record>): Uint8Array {
+  export function encode (obj: Partial<Record>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, Record.codec())
   }
 
@@ -370,7 +370,7 @@ export namespace Message {
       value: Message.ConnectionType
     }
 
-    export function encode (obj: Partial<Peer>): Uint8Array {
+    export function encode (obj: Partial<Peer>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, Peer.codec())
     }
 
@@ -629,7 +629,7 @@ export namespace Message {
     index: number
   }
 
-  export function encode (obj: Partial<Message>): Uint8Array {
+  export function encode (obj: Partial<Message>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, Message.codec())
   }
 

--- a/packages/protons/test/fixtures/maps.ts
+++ b/packages/protons/test/fixtures/maps.ts
@@ -138,7 +138,7 @@ export namespace SubMessage {
     value: number
   }
 
-  export function encode (obj: Partial<SubMessage>): Uint8Array {
+  export function encode (obj: Partial<SubMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, SubMessage.codec())
   }
 
@@ -259,7 +259,7 @@ export namespace MapTypes {
       value: string
     }
 
-    export function encode (obj: Partial<MapTypes$stringMapEntry>): Uint8Array {
+    export function encode (obj: Partial<MapTypes$stringMapEntry>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, MapTypes$stringMapEntry.codec())
     }
 
@@ -371,7 +371,7 @@ export namespace MapTypes {
       value: number
     }
 
-    export function encode (obj: Partial<MapTypes$intMapEntry>): Uint8Array {
+    export function encode (obj: Partial<MapTypes$intMapEntry>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, MapTypes$intMapEntry.codec())
     }
 
@@ -483,7 +483,7 @@ export namespace MapTypes {
       value: boolean
     }
 
-    export function encode (obj: Partial<MapTypes$boolMapEntry>): Uint8Array {
+    export function encode (obj: Partial<MapTypes$boolMapEntry>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, MapTypes$boolMapEntry.codec())
     }
 
@@ -602,7 +602,7 @@ export namespace MapTypes {
       value: number
     }
 
-    export function encode (obj: Partial<MapTypes$messageMapEntry>): Uint8Array {
+    export function encode (obj: Partial<MapTypes$messageMapEntry>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, MapTypes$messageMapEntry.codec())
     }
 
@@ -714,7 +714,7 @@ export namespace MapTypes {
       value: EnumValue
     }
 
-    export function encode (obj: Partial<MapTypes$enumMapEntry>): Uint8Array {
+    export function encode (obj: Partial<MapTypes$enumMapEntry>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, MapTypes$enumMapEntry.codec())
     }
 
@@ -1001,7 +1001,7 @@ export namespace MapTypes {
     value: EnumValue
   }
 
-  export function encode (obj: Partial<MapTypes>): Uint8Array {
+  export function encode (obj: Partial<MapTypes>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, MapTypes.codec())
   }
 

--- a/packages/protons/test/fixtures/noise.ts
+++ b/packages/protons/test/fixtures/noise.ts
@@ -130,7 +130,7 @@ export namespace pb {
       value: Uint8Array
     }
 
-    export function encode (obj: Partial<NoiseHandshakePayload>): Uint8Array {
+    export function encode (obj: Partial<NoiseHandshakePayload>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, NoiseHandshakePayload.codec())
     }
 
@@ -191,7 +191,7 @@ export namespace pb {
     return _codec
   }
 
-  export function encode (obj: Partial<pb>): Uint8Array {
+  export function encode (obj: Partial<pb>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, pb.codec())
   }
 

--- a/packages/protons/test/fixtures/oneof.ts
+++ b/packages/protons/test/fixtures/oneof.ts
@@ -216,7 +216,7 @@ export namespace OneOfMessage {
     value: string
   }
 
-  export function encode (obj: Partial<OneOfMessage>): Uint8Array {
+  export function encode (obj: Partial<OneOfMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, OneOfMessage.codec())
   }
 
@@ -397,7 +397,7 @@ export namespace MessageWithoutOneOfs {
     value: string
   }
 
-  export function encode (obj: Partial<MessageWithoutOneOfs>): Uint8Array {
+  export function encode (obj: Partial<MessageWithoutOneOfs>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, MessageWithoutOneOfs.codec())
   }
 

--- a/packages/protons/test/fixtures/optional.ts
+++ b/packages/protons/test/fixtures/optional.ts
@@ -116,7 +116,7 @@ export namespace OptionalSubMessage {
     value: number
   }
 
-  export function encode (obj: Partial<OptionalSubMessage>): Uint8Array {
+  export function encode (obj: Partial<OptionalSubMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, OptionalSubMessage.codec())
   }
 
@@ -562,7 +562,7 @@ export namespace Optional {
     value: number
   }
 
-  export function encode (obj: Partial<Optional>): Uint8Array {
+  export function encode (obj: Partial<Optional>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, Optional.codec())
   }
 

--- a/packages/protons/test/fixtures/peer.ts
+++ b/packages/protons/test/fixtures/peer.ts
@@ -242,7 +242,7 @@ export namespace Peer {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<Peer>): Uint8Array {
+  export function encode (obj: Partial<Peer>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, Peer.codec())
   }
 
@@ -353,7 +353,7 @@ export namespace Address {
     value: boolean
   }
 
-  export function encode (obj: Partial<Address>): Uint8Array {
+  export function encode (obj: Partial<Address>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, Address.codec())
   }
 
@@ -465,7 +465,7 @@ export namespace Metadata {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<Metadata>): Uint8Array {
+  export function encode (obj: Partial<Metadata>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, Metadata.codec())
   }
 

--- a/packages/protons/test/fixtures/proto2.ts
+++ b/packages/protons/test/fixtures/proto2.ts
@@ -78,7 +78,7 @@ export namespace MessageWithRequired {
     value: number
   }
 
-  export function encode (obj: Partial<MessageWithRequired>): Uint8Array {
+  export function encode (obj: Partial<MessageWithRequired>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, MessageWithRequired.codec())
   }
 

--- a/packages/protons/test/fixtures/protons-options.ts
+++ b/packages/protons/test/fixtures/protons-options.ts
@@ -105,7 +105,7 @@ export namespace MessageWithSizeLimitedRepeatedField {
     value: string
   }
 
-  export function encode (obj: Partial<MessageWithSizeLimitedRepeatedField>): Uint8Array {
+  export function encode (obj: Partial<MessageWithSizeLimitedRepeatedField>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, MessageWithSizeLimitedRepeatedField.codec())
   }
 
@@ -222,7 +222,7 @@ export namespace MessageWithSizeLimitedMap {
       value: string
     }
 
-    export function encode (obj: Partial<MessageWithSizeLimitedMap$mapFieldEntry>): Uint8Array {
+    export function encode (obj: Partial<MessageWithSizeLimitedMap$mapFieldEntry>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, MessageWithSizeLimitedMap$mapFieldEntry.codec())
     }
 
@@ -338,7 +338,7 @@ export namespace MessageWithSizeLimitedMap {
     value: string
   }
 
-  export function encode (obj: Partial<MessageWithSizeLimitedMap>): Uint8Array {
+  export function encode (obj: Partial<MessageWithSizeLimitedMap>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, MessageWithSizeLimitedMap.codec())
   }
 

--- a/packages/protons/test/fixtures/repeated.ts
+++ b/packages/protons/test/fixtures/repeated.ts
@@ -119,7 +119,7 @@ export namespace SubSubMessage {
     value: number
   }
 
-  export function encode (obj: Partial<SubSubMessage>): Uint8Array {
+  export function encode (obj: Partial<SubSubMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, SubSubMessage.codec())
   }
 
@@ -329,7 +329,7 @@ export namespace SubMessage {
     index: number
   }
 
-  export function encode (obj: Partial<SubMessage>): Uint8Array {
+  export function encode (obj: Partial<SubMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, SubMessage.codec())
   }
 
@@ -633,7 +633,7 @@ export namespace RepeatedTypes {
     value: number
   }
 
-  export function encode (obj: Partial<RepeatedTypes>): Uint8Array {
+  export function encode (obj: Partial<RepeatedTypes>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, RepeatedTypes.codec())
   }
 

--- a/packages/protons/test/fixtures/singular.ts
+++ b/packages/protons/test/fixtures/singular.ts
@@ -120,7 +120,7 @@ export namespace SingularSubMessage {
     value: number
   }
 
-  export function encode (obj: Partial<SingularSubMessage>): Uint8Array {
+  export function encode (obj: Partial<SingularSubMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, SingularSubMessage.codec())
   }
 
@@ -583,7 +583,7 @@ export namespace Singular {
     value: number
   }
 
-  export function encode (obj: Partial<Singular>): Uint8Array {
+  export function encode (obj: Partial<Singular>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, Singular.codec())
   }
 

--- a/packages/protons/test/fixtures/streaming.ts
+++ b/packages/protons/test/fixtures/streaming.ts
@@ -141,7 +141,7 @@ export namespace MessageWithArrayField {
     value: string
   }
 
-  export function encode (obj: Partial<MessageWithArrayField>): Uint8Array {
+  export function encode (obj: Partial<MessageWithArrayField>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, MessageWithArrayField.codec())
   }
 
@@ -230,7 +230,7 @@ export namespace NestedMessage {
     value: string
   }
 
-  export function encode (obj: Partial<NestedMessage>): Uint8Array {
+  export function encode (obj: Partial<NestedMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, NestedMessage.codec())
   }
 
@@ -343,7 +343,7 @@ export namespace MessageWithNestedMessage {
     value: string
   }
 
-  export function encode (obj: Partial<MessageWithNestedMessage>): Uint8Array {
+  export function encode (obj: Partial<MessageWithNestedMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, MessageWithNestedMessage.codec())
   }
 
@@ -461,7 +461,7 @@ export namespace MessageWithDeeplyNestedMessage {
     value: string
   }
 
-  export function encode (obj: Partial<MessageWithDeeplyNestedMessage>): Uint8Array {
+  export function encode (obj: Partial<MessageWithDeeplyNestedMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, MessageWithDeeplyNestedMessage.codec())
   }
 
@@ -597,7 +597,7 @@ export namespace MessageWithRepeatedMessage {
     index: number
   }
 
-  export function encode (obj: Partial<MessageWithRepeatedMessage>): Uint8Array {
+  export function encode (obj: Partial<MessageWithRepeatedMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, MessageWithRepeatedMessage.codec())
   }
 
@@ -716,7 +716,7 @@ export namespace MessageWithMapMessage {
       value: string
     }
 
-    export function encode (obj: Partial<MessageWithMapMessage$nestedMessagesEntry>): Uint8Array {
+    export function encode (obj: Partial<MessageWithMapMessage$nestedMessagesEntry>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, MessageWithMapMessage$nestedMessagesEntry.codec())
     }
 
@@ -846,7 +846,7 @@ export namespace MessageWithMapMessage {
     key: string
   }
 
-  export function encode (obj: Partial<MessageWithMapMessage>): Uint8Array {
+  export function encode (obj: Partial<MessageWithMapMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, MessageWithMapMessage.codec())
   }
 
@@ -964,7 +964,7 @@ export namespace MessageWithPrimitiveMap {
       value: string
     }
 
-    export function encode (obj: Partial<MessageWithPrimitiveMap$nestedStringsEntry>): Uint8Array {
+    export function encode (obj: Partial<MessageWithPrimitiveMap$nestedStringsEntry>): Uint8Array<ArrayBuffer> {
       return encodeMessage(obj, MessageWithPrimitiveMap$nestedStringsEntry.codec())
     }
 
@@ -1094,7 +1094,7 @@ export namespace MessageWithPrimitiveMap {
     value: string
   }
 
-  export function encode (obj: Partial<MessageWithPrimitiveMap>): Uint8Array {
+  export function encode (obj: Partial<MessageWithPrimitiveMap>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, MessageWithPrimitiveMap.codec())
   }
 

--- a/packages/protons/test/fixtures/test.ts
+++ b/packages/protons/test/fixtures/test.ts
@@ -94,7 +94,7 @@ export namespace SubMessage {
     value: string
   }
 
-  export function encode (obj: Partial<SubMessage>): Uint8Array {
+  export function encode (obj: Partial<SubMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, SubMessage.codec())
   }
 
@@ -578,7 +578,7 @@ export namespace AllTheTypes {
     value: bigint
   }
 
-  export function encode (obj: Partial<AllTheTypes>): Uint8Array {
+  export function encode (obj: Partial<AllTheTypes>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, AllTheTypes.codec())
   }
 


### PR DESCRIPTION
Since https://github.com/microsoft/TypeScript/pull/59417 `Uint8Array`s are generic so update the types here to be explicit about what backing buffer is used, but be flexible enough to accept any type of backing buffer.

BREAKING CHANGE: Returned `Uint8Array`s are now generic