### PR TITLE
fix: add backing buffer type to Uint8Array fields

### DIFF
--- a/packages/protons/src/types/module.ts
+++ b/packages/protons/src/types/module.ts
@@ -9,7 +9,7 @@ import type { Type } from './index.ts'
 
 const types: Record<string, string> = {
   bool: 'boolean',
-  bytes: 'Uint8Array',
+  bytes: 'Uint8Array<ArrayBuffer>',
   double: 'number',
   fixed32: 'number',
   fixed64: 'bigint',

--- a/packages/protons/test/fixtures/bitswap.ts
+++ b/packages/protons/test/fixtures/bitswap.ts
@@ -5,7 +5,7 @@ import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface Message {
   wantlist?: Message.Wantlist
-  blocks: Uint8Array[]
+  blocks: Uint8Array<ArrayBuffer>[]
   payload: Message.Block[]
   blockPresences: Message.BlockPresence[]
   pendingBytes: number
@@ -35,7 +35,7 @@ export namespace Message {
     }
 
     export interface Entry {
-      block: Uint8Array
+      block: Uint8Array<ArrayBuffer>
       priority: number
       cancel?: boolean
       wantType: Message.Wantlist.WantType
@@ -178,7 +178,7 @@ export namespace Message {
 
       export interface EntryBlockFieldEvent {
         field: '$.block'
-        value: Uint8Array
+        value: Uint8Array<ArrayBuffer>
       }
 
       export interface EntryPriorityFieldEvent {
@@ -322,7 +322,7 @@ export namespace Message {
 
     export interface WantlistEntriesBlockFieldEvent {
       field: '$.entries[].block'
-      value: Uint8Array
+      value: Uint8Array<ArrayBuffer>
       index: number
     }
 
@@ -369,8 +369,8 @@ export namespace Message {
   }
 
   export interface Block {
-    prefix: Uint8Array
-    data: Uint8Array
+    prefix: Uint8Array<ArrayBuffer>
+    data: Uint8Array<ArrayBuffer>
   }
 
   export namespace Block {
@@ -459,12 +459,12 @@ export namespace Message {
 
     export interface BlockPrefixFieldEvent {
       field: '$.prefix'
-      value: Uint8Array
+      value: Uint8Array<ArrayBuffer>
     }
 
     export interface BlockDataFieldEvent {
       field: '$.data'
-      value: Uint8Array
+      value: Uint8Array<ArrayBuffer>
     }
 
     export function encode (obj: Partial<Block>): Uint8Array<ArrayBuffer> {
@@ -497,7 +497,7 @@ export namespace Message {
   }
 
   export interface BlockPresence {
-    cid: Uint8Array
+    cid: Uint8Array<ArrayBuffer>
     type: Message.BlockPresenceType
   }
 
@@ -587,7 +587,7 @@ export namespace Message {
 
     export interface BlockPresenceCidFieldEvent {
       field: '$.cid'
-      value: Uint8Array
+      value: Uint8Array<ArrayBuffer>
     }
 
     export interface BlockPresenceTypeFieldEvent {
@@ -803,7 +803,7 @@ export namespace Message {
 
   export interface MessageWantlistEntriesBlockFieldEvent {
     field: '$.wantlist.entries[].block'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
     index: number
   }
 
@@ -839,24 +839,24 @@ export namespace Message {
   export interface MessageBlocksFieldEvent {
     field: '$.blocks[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface MessagePayloadPrefixFieldEvent {
     field: '$.payload[].prefix'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
     index: number
   }
 
   export interface MessagePayloadDataFieldEvent {
     field: '$.payload[].data'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
     index: number
   }
 
   export interface MessageBlockPresencesCidFieldEvent {
     field: '$.blockPresences[].cid'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
     index: number
   }
 

--- a/packages/protons/test/fixtures/circuit.ts
+++ b/packages/protons/test/fixtures/circuit.ts
@@ -76,8 +76,8 @@ export namespace CircuitRelay {
   }
 
   export interface Peer {
-    id: Uint8Array
-    addrs: Uint8Array[]
+    id: Uint8Array<ArrayBuffer>
+    addrs: Uint8Array<ArrayBuffer>[]
   }
 
   export namespace Peer {
@@ -184,13 +184,13 @@ export namespace CircuitRelay {
 
     export interface PeerIdFieldEvent {
       field: '$.id'
-      value: Uint8Array
+      value: Uint8Array<ArrayBuffer>
     }
 
     export interface PeerAddrsFieldEvent {
       field: '$.addrs[]'
       index: number
-      value: Uint8Array
+      value: Uint8Array<ArrayBuffer>
     }
 
     export function encode (obj: Partial<Peer>): Uint8Array<ArrayBuffer> {
@@ -329,24 +329,24 @@ export namespace CircuitRelay {
 
   export interface CircuitRelaySrcPeerIdFieldEvent {
     field: '$.srcPeer.id'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface CircuitRelaySrcPeerAddrsFieldEvent {
     field: '$.srcPeer.addrs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface CircuitRelayDstPeerIdFieldEvent {
     field: '$.dstPeer.id'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface CircuitRelayDstPeerAddrsFieldEvent {
     field: '$.dstPeer.addrs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface CircuitRelayCodeFieldEvent {

--- a/packages/protons/test/fixtures/daemon.ts
+++ b/packages/protons/test/fixtures/daemon.ts
@@ -265,13 +265,13 @@ export namespace Request {
 
   export interface RequestConnectPeerFieldEvent {
     field: '$.connect.peer'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RequestConnectAddrsFieldEvent {
     field: '$.connect.addrs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RequestConnectTimeoutFieldEvent {
@@ -281,7 +281,7 @@ export namespace Request {
 
   export interface RequestStreamOpenPeerFieldEvent {
     field: '$.streamOpen.peer'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RequestStreamOpenProtoFieldEvent {
@@ -297,7 +297,7 @@ export namespace Request {
 
   export interface RequestStreamHandlerAddrFieldEvent {
     field: '$.streamHandler.addr'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RequestStreamHandlerProtoFieldEvent {
@@ -313,22 +313,22 @@ export namespace Request {
 
   export interface RequestDhtPeerFieldEvent {
     field: '$.dht.peer'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RequestDhtCidFieldEvent {
     field: '$.dht.cid'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RequestDhtKeyFieldEvent {
     field: '$.dht.key'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RequestDhtValueFieldEvent {
     field: '$.dht.value'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RequestDhtCountFieldEvent {
@@ -348,7 +348,7 @@ export namespace Request {
 
   export interface RequestConnManagerPeerFieldEvent {
     field: '$.connManager.peer'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RequestConnManagerTagFieldEvent {
@@ -363,7 +363,7 @@ export namespace Request {
 
   export interface RequestDisconnectPeerFieldEvent {
     field: '$.disconnect.peer'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RequestPubsubTypeFieldEvent {
@@ -378,7 +378,7 @@ export namespace Request {
 
   export interface RequestPubsubDataFieldEvent {
     field: '$.pubsub.data'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RequestPeerStoreTypeFieldEvent {
@@ -388,7 +388,7 @@ export namespace Request {
 
   export interface RequestPeerStoreIdFieldEvent {
     field: '$.peerStore.id'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RequestPeerStoreProtosFieldEvent {
@@ -664,12 +664,12 @@ export namespace Response {
 
   export interface ResponseStreamInfoPeerFieldEvent {
     field: '$.streamInfo.peer'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface ResponseStreamInfoAddrFieldEvent {
     field: '$.streamInfo.addr'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface ResponseStreamInfoProtoFieldEvent {
@@ -679,13 +679,13 @@ export namespace Response {
 
   export interface ResponseIdentifyIdFieldEvent {
     field: '$.identify.id'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface ResponseIdentifyAddrsFieldEvent {
     field: '$.identify.addrs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface ResponseDhtTypeFieldEvent {
@@ -695,30 +695,30 @@ export namespace Response {
 
   export interface ResponseDhtPeerIdFieldEvent {
     field: '$.dht.peer.id'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface ResponseDhtPeerAddrsFieldEvent {
     field: '$.dht.peer.addrs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface ResponseDhtValueFieldEvent {
     field: '$.dht.value'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface ResponsePeersIdFieldEvent {
     field: '$.peers[].id'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
     index: number
   }
 
   export interface ResponsePeersAddrsFieldEvent {
     field: '$.peers[].addrs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface ResponsePubsubTopicsFieldEvent {
@@ -730,18 +730,18 @@ export namespace Response {
   export interface ResponsePubsubPeerIDsFieldEvent {
     field: '$.pubsub.peerIDs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface ResponsePeerStorePeerIdFieldEvent {
     field: '$.peerStore.peer.id'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface ResponsePeerStorePeerAddrsFieldEvent {
     field: '$.peerStore.peer.addrs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface ResponsePeerStoreProtosFieldEvent {
@@ -764,8 +764,8 @@ export namespace Response {
 }
 
 export interface IdentifyResponse {
-  id: Uint8Array
-  addrs: Uint8Array[]
+  id: Uint8Array<ArrayBuffer>
+  addrs: Uint8Array<ArrayBuffer>[]
 }
 
 export namespace IdentifyResponse {
@@ -872,13 +872,13 @@ export namespace IdentifyResponse {
 
   export interface IdentifyResponseIdFieldEvent {
     field: '$.id'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface IdentifyResponseAddrsFieldEvent {
     field: '$.addrs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export function encode (obj: Partial<IdentifyResponse>): Uint8Array<ArrayBuffer> {
@@ -895,8 +895,8 @@ export namespace IdentifyResponse {
 }
 
 export interface ConnectRequest {
-  peer: Uint8Array
-  addrs: Uint8Array[]
+  peer: Uint8Array<ArrayBuffer>
+  addrs: Uint8Array<ArrayBuffer>[]
   timeout?: bigint
 }
 
@@ -1020,13 +1020,13 @@ export namespace ConnectRequest {
 
   export interface ConnectRequestPeerFieldEvent {
     field: '$.peer'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface ConnectRequestAddrsFieldEvent {
     field: '$.addrs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface ConnectRequestTimeoutFieldEvent {
@@ -1048,7 +1048,7 @@ export namespace ConnectRequest {
 }
 
 export interface StreamOpenRequest {
-  peer: Uint8Array
+  peer: Uint8Array<ArrayBuffer>
   proto: string[]
   timeout?: bigint
 }
@@ -1173,7 +1173,7 @@ export namespace StreamOpenRequest {
 
   export interface StreamOpenRequestPeerFieldEvent {
     field: '$.peer'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface StreamOpenRequestProtoFieldEvent {
@@ -1201,7 +1201,7 @@ export namespace StreamOpenRequest {
 }
 
 export interface StreamHandlerRequest {
-  addr: Uint8Array
+  addr: Uint8Array<ArrayBuffer>
   proto: string[]
 }
 
@@ -1309,7 +1309,7 @@ export namespace StreamHandlerRequest {
 
   export interface StreamHandlerRequestAddrFieldEvent {
     field: '$.addr'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface StreamHandlerRequestProtoFieldEvent {
@@ -1421,8 +1421,8 @@ export namespace ErrorResponse {
 }
 
 export interface StreamInfo {
-  peer: Uint8Array
-  addr: Uint8Array
+  peer: Uint8Array<ArrayBuffer>
+  addr: Uint8Array<ArrayBuffer>
   proto: string
 }
 
@@ -1529,12 +1529,12 @@ export namespace StreamInfo {
 
   export interface StreamInfoPeerFieldEvent {
     field: '$.peer'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface StreamInfoAddrFieldEvent {
     field: '$.addr'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface StreamInfoProtoFieldEvent {
@@ -1557,10 +1557,10 @@ export namespace StreamInfo {
 
 export interface DHTRequest {
   type: DHTRequest.Type
-  peer?: Uint8Array
-  cid?: Uint8Array
-  key?: Uint8Array
-  value?: Uint8Array
+  peer?: Uint8Array<ArrayBuffer>
+  cid?: Uint8Array<ArrayBuffer>
+  key?: Uint8Array<ArrayBuffer>
+  value?: Uint8Array<ArrayBuffer>
   count?: number
   timeout?: bigint
 }
@@ -1765,22 +1765,22 @@ export namespace DHTRequest {
 
   export interface DHTRequestPeerFieldEvent {
     field: '$.peer'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface DHTRequestCidFieldEvent {
     field: '$.cid'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface DHTRequestKeyFieldEvent {
     field: '$.key'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface DHTRequestValueFieldEvent {
     field: '$.value'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface DHTRequestCountFieldEvent {
@@ -1809,7 +1809,7 @@ export namespace DHTRequest {
 export interface DHTResponse {
   type: DHTResponse.Type
   peer?: PeerInfo
-  value?: Uint8Array
+  value?: Uint8Array<ArrayBuffer>
 }
 
 export namespace DHTResponse {
@@ -1938,18 +1938,18 @@ export namespace DHTResponse {
 
   export interface DHTResponsePeerIdFieldEvent {
     field: '$.peer.id'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface DHTResponsePeerAddrsFieldEvent {
     field: '$.peer.addrs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface DHTResponseValueFieldEvent {
     field: '$.value'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export function encode (obj: Partial<DHTResponse>): Uint8Array<ArrayBuffer> {
@@ -1966,8 +1966,8 @@ export namespace DHTResponse {
 }
 
 export interface PeerInfo {
-  id: Uint8Array
-  addrs: Uint8Array[]
+  id: Uint8Array<ArrayBuffer>
+  addrs: Uint8Array<ArrayBuffer>[]
 }
 
 export namespace PeerInfo {
@@ -2074,13 +2074,13 @@ export namespace PeerInfo {
 
   export interface PeerInfoIdFieldEvent {
     field: '$.id'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface PeerInfoAddrsFieldEvent {
     field: '$.addrs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export function encode (obj: Partial<PeerInfo>): Uint8Array<ArrayBuffer> {
@@ -2098,7 +2098,7 @@ export namespace PeerInfo {
 
 export interface ConnManagerRequest {
   type: ConnManagerRequest.Type
-  peer?: Uint8Array
+  peer?: Uint8Array<ArrayBuffer>
   tag?: string
   weight?: bigint
 }
@@ -2243,7 +2243,7 @@ export namespace ConnManagerRequest {
 
   export interface ConnManagerRequestPeerFieldEvent {
     field: '$.peer'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface ConnManagerRequestTagFieldEvent {
@@ -2270,7 +2270,7 @@ export namespace ConnManagerRequest {
 }
 
 export interface DisconnectRequest {
-  peer: Uint8Array
+  peer: Uint8Array<ArrayBuffer>
 }
 
 export namespace DisconnectRequest {
@@ -2342,7 +2342,7 @@ export namespace DisconnectRequest {
 
   export interface DisconnectRequestPeerFieldEvent {
     field: '$.peer'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export function encode (obj: Partial<DisconnectRequest>): Uint8Array<ArrayBuffer> {
@@ -2361,7 +2361,7 @@ export namespace DisconnectRequest {
 export interface PSRequest {
   type: PSRequest.Type
   topic?: string
-  data?: Uint8Array
+  data?: Uint8Array<ArrayBuffer>
 }
 
 export namespace PSRequest {
@@ -2495,7 +2495,7 @@ export namespace PSRequest {
 
   export interface PSRequestDataFieldEvent {
     field: '$.data'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export function encode (obj: Partial<PSRequest>): Uint8Array<ArrayBuffer> {
@@ -2512,12 +2512,12 @@ export namespace PSRequest {
 }
 
 export interface PSMessage {
-  from?: Uint8Array
-  data?: Uint8Array
-  seqno?: Uint8Array
+  from?: Uint8Array<ArrayBuffer>
+  data?: Uint8Array<ArrayBuffer>
+  seqno?: Uint8Array<ArrayBuffer>
   topicIDs: string[]
-  signature?: Uint8Array
-  key?: Uint8Array
+  signature?: Uint8Array<ArrayBuffer>
+  key?: Uint8Array<ArrayBuffer>
 }
 
 export namespace PSMessage {
@@ -2687,17 +2687,17 @@ export namespace PSMessage {
 
   export interface PSMessageFromFieldEvent {
     field: '$.from'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface PSMessageDataFieldEvent {
     field: '$.data'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface PSMessageSeqnoFieldEvent {
     field: '$.seqno'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface PSMessageTopicIDsFieldEvent {
@@ -2708,12 +2708,12 @@ export namespace PSMessage {
 
   export interface PSMessageSignatureFieldEvent {
     field: '$.signature'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface PSMessageKeyFieldEvent {
     field: '$.key'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export function encode (obj: Partial<PSMessage>): Uint8Array<ArrayBuffer> {
@@ -2731,7 +2731,7 @@ export namespace PSMessage {
 
 export interface PSResponse {
   topics: string[]
-  peerIDs: Uint8Array[]
+  peerIDs: Uint8Array<ArrayBuffer>[]
 }
 
 export namespace PSResponse {
@@ -2860,7 +2860,7 @@ export namespace PSResponse {
   export interface PSResponsePeerIDsFieldEvent {
     field: '$.peerIDs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export function encode (obj: Partial<PSResponse>): Uint8Array<ArrayBuffer> {
@@ -2878,7 +2878,7 @@ export namespace PSResponse {
 
 export interface PeerstoreRequest {
   type: PeerstoreRequest.Type
-  id?: Uint8Array
+  id?: Uint8Array<ArrayBuffer>
   protos: string[]
 }
 
@@ -3025,7 +3025,7 @@ export namespace PeerstoreRequest {
 
   export interface PeerstoreRequestIdFieldEvent {
     field: '$.id'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface PeerstoreRequestProtosFieldEvent {
@@ -3157,13 +3157,13 @@ export namespace PeerstoreResponse {
 
   export interface PeerstoreResponsePeerIdFieldEvent {
     field: '$.peer.id'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface PeerstoreResponsePeerAddrsFieldEvent {
     field: '$.peer.addrs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface PeerstoreResponseProtosFieldEvent {

--- a/packages/protons/test/fixtures/dht.ts
+++ b/packages/protons/test/fixtures/dht.ts
@@ -3,10 +3,10 @@ import type { Codec, DecodeOptions } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
 
 export interface Record {
-  key?: Uint8Array
-  value?: Uint8Array
-  author?: Uint8Array
-  signature?: Uint8Array
+  key?: Uint8Array<ArrayBuffer>
+  value?: Uint8Array<ArrayBuffer>
+  author?: Uint8Array<ArrayBuffer>
+  signature?: Uint8Array<ArrayBuffer>
   timeReceived?: string
 }
 
@@ -141,22 +141,22 @@ export namespace Record {
 
   export interface RecordKeyFieldEvent {
     field: '$.key'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RecordValueFieldEvent {
     field: '$.value'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RecordAuthorFieldEvent {
     field: '$.author'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RecordSignatureFieldEvent {
     field: '$.signature'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface RecordTimeReceivedFieldEvent {
@@ -180,8 +180,8 @@ export namespace Record {
 export interface Message {
   type?: Message.MessageType
   clusterLevelRaw?: number
-  key?: Uint8Array
-  record?: Uint8Array
+  key?: Uint8Array<ArrayBuffer>
+  record?: Uint8Array<ArrayBuffer>
   closerPeers: Message.Peer[]
   providerPeers: Message.Peer[]
 }
@@ -232,8 +232,8 @@ export namespace Message {
   }
 
   export interface Peer {
-    id?: Uint8Array
-    addrs: Uint8Array[]
+    id?: Uint8Array<ArrayBuffer>
+    addrs: Uint8Array<ArrayBuffer>[]
     connection?: Message.ConnectionType
   }
 
@@ -356,13 +356,13 @@ export namespace Message {
 
     export interface PeerIdFieldEvent {
       field: '$.id'
-      value: Uint8Array
+      value: Uint8Array<ArrayBuffer>
     }
 
     export interface PeerAddrsFieldEvent {
       field: '$.addrs[]'
       index: number
-      value: Uint8Array
+      value: Uint8Array<ArrayBuffer>
     }
 
     export interface PeerConnectionFieldEvent {
@@ -585,24 +585,24 @@ export namespace Message {
 
   export interface MessageKeyFieldEvent {
     field: '$.key'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface MessageRecordFieldEvent {
     field: '$.record'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface MessageCloserPeersIdFieldEvent {
     field: '$.closerPeers[].id'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
     index: number
   }
 
   export interface MessageCloserPeersAddrsFieldEvent {
     field: '$.closerPeers[].addrs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface MessageCloserPeersConnectionFieldEvent {
@@ -613,14 +613,14 @@ export namespace Message {
 
   export interface MessageProviderPeersIdFieldEvent {
     field: '$.providerPeers[].id'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
     index: number
   }
 
   export interface MessageProviderPeersAddrsFieldEvent {
     field: '$.providerPeers[].addrs[]'
     index: number
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface MessageProviderPeersConnectionFieldEvent {

--- a/packages/protons/test/fixtures/noise.ts
+++ b/packages/protons/test/fixtures/noise.ts
@@ -9,9 +9,9 @@ export interface pb {}
 
 export namespace pb {
   export interface NoiseHandshakePayload {
-    identityKey: Uint8Array
-    identitySig: Uint8Array
-    data: Uint8Array
+    identityKey: Uint8Array<ArrayBuffer>
+    identitySig: Uint8Array<ArrayBuffer>
+    data: Uint8Array<ArrayBuffer>
   }
 
   export namespace NoiseHandshakePayload {
@@ -117,17 +117,17 @@ export namespace pb {
 
     export interface NoiseHandshakePayloadIdentityKeyFieldEvent {
       field: '$.identityKey'
-      value: Uint8Array
+      value: Uint8Array<ArrayBuffer>
     }
 
     export interface NoiseHandshakePayloadIdentitySigFieldEvent {
       field: '$.identitySig'
-      value: Uint8Array
+      value: Uint8Array<ArrayBuffer>
     }
 
     export interface NoiseHandshakePayloadDataFieldEvent {
       field: '$.data'
-      value: Uint8Array
+      value: Uint8Array<ArrayBuffer>
     }
 
     export function encode (obj: Partial<NoiseHandshakePayload>): Uint8Array<ArrayBuffer> {

--- a/packages/protons/test/fixtures/optional.ts
+++ b/packages/protons/test/fixtures/optional.ts
@@ -144,7 +144,7 @@ export interface Optional {
   sfixed64?: bigint
   bool?: boolean
   string?: string
-  bytes?: Uint8Array
+  bytes?: Uint8Array<ArrayBuffer>
   enum?: OptionalEnum
   subMessage?: OptionalSubMessage
 }
@@ -544,7 +544,7 @@ export namespace Optional {
 
   export interface OptionalBytesFieldEvent {
     field: '$.bytes'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface OptionalEnumFieldEvent {

--- a/packages/protons/test/fixtures/peer.ts
+++ b/packages/protons/test/fixtures/peer.ts
@@ -7,8 +7,8 @@ export interface Peer {
   addresses: Address[]
   protocols: string[]
   metadata: Metadata[]
-  pubKey?: Uint8Array
-  peerRecordEnvelope?: Uint8Array
+  pubKey?: Uint8Array<ArrayBuffer>
+  peerRecordEnvelope?: Uint8Array<ArrayBuffer>
 }
 
 export namespace Peer {
@@ -204,7 +204,7 @@ export namespace Peer {
 
   export interface PeerAddressesMultiaddrFieldEvent {
     field: '$.addresses[].multiaddr'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
     index: number
   }
 
@@ -228,18 +228,18 @@ export namespace Peer {
 
   export interface PeerMetadataValueFieldEvent {
     field: '$.metadata[].value'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
     index: number
   }
 
   export interface PeerPubKeyFieldEvent {
     field: '$.pubKey'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface PeerPeerRecordEnvelopeFieldEvent {
     field: '$.peerRecordEnvelope'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export function encode (obj: Partial<Peer>): Uint8Array<ArrayBuffer> {
@@ -256,7 +256,7 @@ export namespace Peer {
 }
 
 export interface Address {
-  multiaddr: Uint8Array
+  multiaddr: Uint8Array<ArrayBuffer>
   isCertified?: boolean
 }
 
@@ -345,7 +345,7 @@ export namespace Address {
 
   export interface AddressMultiaddrFieldEvent {
     field: '$.multiaddr'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface AddressIsCertifiedFieldEvent {
@@ -368,7 +368,7 @@ export namespace Address {
 
 export interface Metadata {
   key: string
-  value: Uint8Array
+  value: Uint8Array<ArrayBuffer>
 }
 
 export namespace Metadata {
@@ -462,7 +462,7 @@ export namespace Metadata {
 
   export interface MetadataValueFieldEvent {
     field: '$.value'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export function encode (obj: Partial<Metadata>): Uint8Array<ArrayBuffer> {

--- a/packages/protons/test/fixtures/singular.ts
+++ b/packages/protons/test/fixtures/singular.ts
@@ -148,7 +148,7 @@ export interface Singular {
   sfixed64: bigint
   bool: boolean
   string: string
-  bytes: Uint8Array
+  bytes: Uint8Array<ArrayBuffer>
   enum: SingularEnum
   subMessage?: SingularSubMessage
 }
@@ -565,7 +565,7 @@ export namespace Singular {
 
   export interface SingularBytesFieldEvent {
     field: '$.bytes'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface SingularEnumFieldEvent {

--- a/packages/protons/test/fixtures/test.ts
+++ b/packages/protons/test/fixtures/test.ts
@@ -118,7 +118,7 @@ export interface AllTheTypes {
   field8?: number
   field9?: number
   field10?: string
-  field11?: Uint8Array
+  field11?: Uint8Array<ArrayBuffer>
   field12?: AnEnum
   field13?: SubMessage
   field14: string[]
@@ -539,7 +539,7 @@ export namespace AllTheTypes {
 
   export interface AllTheTypesField11FieldEvent {
     field: '$.field11'
-    value: Uint8Array
+    value: Uint8Array<ArrayBuffer>
   }
 
   export interface AllTheTypesField12FieldEvent {


### PR DESCRIPTION
Where a Uint8Array field is declared, add the explicit `<ArrayBuffer>` generic type to allow use with onward APIs that require certain backing buffer types.